### PR TITLE
nix: replace deprecated pnpm package attrs

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -2,11 +2,12 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  symlinkJoin,
+  fetchPnpmDeps,
   # Build dependencies
   meson,
   typescript,
   pnpm,
+  pnpmConfigHook,
   pkg-config,
   ninja,
   gobject-introspection,
@@ -62,14 +63,15 @@ in
     };
 
     pnpmInstallFlags = ["--dev"]; # don't install TSC
-    pnpmDeps = pnpm.fetchDeps {
+    pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname src;
       hash = "sha256-T3GyHkGqwNjLC8EYdnABrjn0Wh+4xSW6dPNN97VlUjo=";
       fetcherVersion = 2; # https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion
     };
 
     nativeBuildInputs = [
-      pnpm.configHook # dependency resolution
+      pnpm
+      pnpmConfigHook # dependency resolution
 
       pkg-config
       meson


### PR DESCRIPTION
fix the deprecation warnings on latest nix, also symlinkJoin goes unused so just remove it too

```
evaluation warning: pnpm.configHook: The package attribue is deprecated. Use the top-level pnpmConfigHook attribute instead
evaluation warning: pnpm.fetchDeps: The package attribute is deprecated. Use the top-level fetchPnpmDeps attribute instead
```