### PR TITLE
chore: drop various bits marked for deprecations; cleanup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,14 @@ const APP_BUS = (name: string) => `${pkg.name}.${name}`;
 const APP_PATH = (name: string) => `/${pkg.name.split('.').join('/')}/${name}`;
 const DEFAULT_CONF = `${GLib.get_user_config_dir()}/${BIN_NAME}/config.js`;
 
+function nextArg(args: string[], i: number, flag: string): string {
+    if (i + 1 >= args.length) {
+        console.error(`${flag} requires an argument`);
+        return '';
+    }
+    return args[i + 1];
+}
+
 const help = (bin: string) => `USAGE:
     ${bin} [OPTIONS]
 
@@ -77,12 +85,14 @@ export async function main(args: string[]) {
 
             case '-b':
             case '--bus-name':
-                flags.busName = args[++i];
+                flags.busName = nextArg(args, i, args[i]);
+                ++i;
                 break;
 
             case '-c':
             case '--config':
-                flags.config = parsePath(args[++i]);
+                flags.config = parsePath(nextArg(args, i, args[i]));
+                ++i;
                 break;
 
             case 'inspector':
@@ -99,26 +109,30 @@ export async function main(args: string[]) {
             case 'run-js':
             case '-r':
             case '--run-js':
-                flags.runJs = args[++i];
+                flags.runJs = nextArg(args, i, args[i]);
+                ++i;
                 break;
 
             case 'run-file':
             case '-f':
             case '--run-file':
-                flags.runFile = parsePath(args[++i]);
+                flags.runFile = parsePath(nextArg(args, i, args[i]));
+                ++i;
                 break;
 
             // FIXME: deprecated
             case 'run-promise':
             case '-p':
             case '--run-promise':
-                flags.runPromise = args[++i];
+                flags.runPromise = nextArg(args, i, args[i]);
+                ++i;
                 break;
 
             case 'toggle-window':
             case '-t':
             case '--toggle-window':
-                flags.toggleWindow = args[++i];
+                flags.toggleWindow = nextArg(args, i, args[i]);
+                ++i;
                 break;
 
             case 'quit':

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,6 +1,31 @@
 import GObject from 'gi://GObject';
 import { pspec, registerGObject, PspecFlag, PspecType } from './utils/gobject.js';
 
+function shallowEqual(a: unknown, b: unknown): boolean {
+    if (a === b) return true;
+    if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
+    const keysA = Object.keys(a as Record<string, unknown>);
+    const keysB = Object.keys(b as Record<string, unknown>);
+    if (keysA.length !== keysB.length) return false;
+    for (const key of keysA) {
+        if ((a as any)[key] !== (b as any)[key]) return false;
+    }
+    return true;
+}
+
+const kebabToCamelCache = new Map<string, string>();
+
+function kebabToCamel(prop: string): string {
+    let result = kebabToCamelCache.get(prop);
+    if (result !== undefined) return result;
+    result = prop
+        .split('-')
+        .map((w, i) => (i > 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+        .join('');
+    kebabToCamelCache.set(prop, result);
+    return result;
+}
+
 /**
  * An object that supports signal connections and disconnections.
  */
@@ -219,16 +244,9 @@ export default class Service extends GObject.Object {
      * @param value - The new value
      */
     updateProperty(prop: string, value: unknown) {
-        if (
-            this[prop as keyof typeof this] === value ||
-            JSON.stringify(this[prop as keyof typeof this]) === JSON.stringify(value)
-        )
-            return;
+        if (shallowEqual(this[prop as keyof typeof this], value)) return;
 
-        const privateProp = prop
-            .split('-')
-            .map((w, i) => (i > 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
-            .join('');
+        const privateProp = kebabToCamel(prop);
 
         // @ts-expect-error
         this[`_${privateProp}`] = value;

--- a/src/service/applications.ts
+++ b/src/service/applications.ts
@@ -135,6 +135,7 @@ export class Applications extends Service {
 
     private _list!: Application[];
     private _frequents: { [app: string]: number };
+    private _frequencyBindings: Array<{ app: Application; id: number }> = [];
 
     /**
      * Filters and sorts applications by a search term, ordered by launch frequency.
@@ -143,11 +144,7 @@ export class Applications extends Service {
      * @returns Matching applications sorted by frequency (most used first)
      */
     readonly query = (term: string) => {
-        return this._list
-            .filter(app => app.match(term))
-            .sort((a, b) => {
-                return a.frequency < b.frequency ? 1 : 0;
-            });
+        return this._list.filter(app => app.match(term)).sort((a, b) => b.frequency - a.frequency);
     };
 
     constructor() {
@@ -188,17 +185,23 @@ export class Applications extends Service {
 
     /** Reloads the application list from the system and restores frequency data. */
     readonly reload = () => {
+        for (const { app, id } of this._frequencyBindings) {
+            app.disconnect(id);
+        }
+        this._frequencyBindings = [];
+
         this._list = Gio.AppInfo.get_all()
             .filter(app => app.should_show())
             .map(app => Gio.DesktopAppInfo.new(app.get_id() || ''))
             .filter(app => app)
             .map(app => new Application(app, this.frequents[app.get_id() || '']));
 
-        this._list.forEach(app =>
-            app.connect('notify::frequency', () => {
+        this._list.forEach(app => {
+            const id = app.connect('notify::frequency', () => {
                 this._launched(app.desktop);
-            }),
-        );
+            });
+            this._frequencyBindings.push({ app, id });
+        });
 
         this.changed('list');
     };

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -266,17 +266,6 @@ export class Hyprland extends Service {
         });
     }
 
-    /**
-     * @deprecated Use {@link message} or {@link messageAsync} instead.
-     */
-    readonly sendMessage = (cmd: string) => {
-        console.warn(
-            'hyprland.sendMessage is DEPRECATED, ' +
-                ' use hyprland.message or hyprland.messageAsync',
-        );
-        return this.messageAsync(cmd);
-    };
-
     private _socketStream(cmd: string) {
         const connection = this._connection('socket');
 
@@ -406,29 +395,28 @@ export class Hyprland extends Service {
                     break;
 
                 case 'openwindow':
-                    await this._syncClients(false);
-                    await this._syncWorkspaces(false);
+                    await Promise.all([this._syncClients(false), this._syncWorkspaces(false)]);
                     ['clients', 'workspaces'].forEach(e => this.notify(e));
                     this.emit('client-added', '0x' + argv[0]);
                     break;
 
                 case 'movewindow':
                 case 'windowtitle':
-                    await this._syncClients(false);
-                    await this._syncWorkspaces(false);
+                    await Promise.all([this._syncClients(false), this._syncWorkspaces(false)]);
                     ['clients', 'workspaces'].forEach(e => this.notify(e));
                     break;
 
                 case 'moveworkspace':
-                    await this._syncClients(false);
-                    await this._syncWorkspaces(false);
-                    await this._syncMonitors(false);
+                    await Promise.all([
+                        this._syncClients(false),
+                        this._syncWorkspaces(false),
+                        this._syncMonitors(false),
+                    ]);
                     ['clients', 'workspaces', 'monitors'].forEach(e => this.notify(e));
                     break;
 
                 case 'fullscreen':
-                    await this._syncClients(false);
-                    await this._syncWorkspaces(false);
+                    await Promise.all([this._syncClients(false), this._syncWorkspaces(false)]);
                     ['clients', 'workspaces'].forEach(e => this.notify(e));
                     this.emit('fullscreen', argv[0] === '1');
                     break;
@@ -445,8 +433,7 @@ export class Hyprland extends Service {
                     break;
 
                 case 'closewindow':
-                    await this._syncWorkspaces(false);
-                    await this._syncClients(false);
+                    await Promise.all([this._syncWorkspaces(false), this._syncClients(false)]);
                     if (this._active.client.address === '0x' + argv[0]) {
                         this._active.client.updateProperty('class', '');
                         this._active.client.updateProperty('title', '');

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -194,6 +194,7 @@ export class MprisPlayer extends Service {
     private _binding = { mpris: [0, 0], player: 0 };
     private _mprisProxy: MprisProxy;
     private _playerProxy: PlayerProxy;
+    private _rawPlayerProxy: Gio.DBusProxy;
 
     constructor(busName: string) {
         super();
@@ -204,6 +205,16 @@ export class MprisPlayer extends Service {
         this._mprisProxy = new MprisProxy(Gio.DBus.session, busName, '/org/mpris/MediaPlayer2');
 
         this._playerProxy = new PlayerProxy(Gio.DBus.session, busName, '/org/mpris/MediaPlayer2');
+
+        this._rawPlayerProxy = Gio.DBusProxy.new_for_bus_sync(
+            Gio.BusType.SESSION,
+            Gio.DBusProxyFlags.NONE,
+            null,
+            busName,
+            '/org/mpris/MediaPlayer2',
+            'org.mpris.MediaPlayer2.Player',
+            null,
+        );
 
         this._onPlayerProxyReady();
         this._onMprisProxyReady();
@@ -326,17 +337,7 @@ export class MprisPlayer extends Service {
 
     /** Current playback position in seconds (-1 if unavailable). */
     get position() {
-        const proxy = Gio.DBusProxy.new_for_bus_sync(
-            Gio.BusType.SESSION,
-            Gio.DBusProxyFlags.NONE,
-            null,
-            this._busName,
-            '/org/mpris/MediaPlayer2',
-            'org.mpris.MediaPlayer2.Player',
-            null,
-        );
-
-        const pos = proxy.get_cached_property('Position')?.unpack() as number;
+        const pos = this._rawPlayerProxy.get_cached_property('Position')?.unpack() as number;
         return pos ? pos / 1_000_000 : -1;
     }
 

--- a/src/service/notifications.ts
+++ b/src/service/notifications.ts
@@ -446,6 +446,7 @@ export class Notifications extends Service {
     private _notifications: Map<number, Notification>;
     private _dnd = false;
     private _idCount = 1;
+    private _cacheTimeoutId = 0;
 
     constructor() {
         super();
@@ -673,9 +674,14 @@ export class Notifications extends Service {
     }
 
     private _cache() {
-        ensureDirectory(NOTIFICATIONS_CACHE_PATH);
-        const arr = Array.from(this._notifications.values()).map(n => n.toJson());
-        writeFile(JSON.stringify(arr, null, 2), CACHE_FILE).catch(err => console.error(err));
+        if (this._cacheTimeoutId) GLib.source_remove(this._cacheTimeoutId);
+        this._cacheTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
+            this._cacheTimeoutId = 0;
+            ensureDirectory(NOTIFICATIONS_CACHE_PATH);
+            const arr = Array.from(this._notifications.values()).map(n => n.toJson());
+            writeFile(JSON.stringify(arr, null, 2), CACHE_FILE).catch(err => console.error(err));
+            return GLib.SOURCE_REMOVE;
+        });
     }
 }
 

--- a/src/utils/binding.ts
+++ b/src/utils/binding.ts
@@ -8,8 +8,6 @@ import { Binding, Connectable } from '../service.js';
 import { Variable } from '../variable.js';
 import { kebabify } from './gobject.js';
 
-// TODO: consider adding a guard for disposed Variables
-
 type Dep<T> = Binding<any, any, T>;
 
 /**
@@ -39,8 +37,21 @@ export function merge<
 >(deps: Deps, fn: (...args: Args) => V) {
     const update = () => fn(...(deps.map(d => d.transformFn(d.emitter[d.prop])) as Args));
     const watcher = new Variable(update());
-    for (const dep of deps)
-        dep.emitter.connect(`notify::${kebabify(dep.prop)}`, () => (watcher.value = update()));
+    const connectionIds: Array<{ emitter: Connectable; id: number }> = [];
+
+    for (const dep of deps) {
+        const id = dep.emitter.connect(
+            `notify::${kebabify(dep.prop)}`,
+            () => (watcher.value = update()),
+        );
+        connectionIds.push({ emitter: dep.emitter, id });
+    }
+
+    watcher.connect('dispose', () => {
+        for (const { emitter, id } of connectionIds) {
+            emitter.disconnect(id);
+        }
+    });
 
     return watcher.bind();
 }
@@ -62,7 +73,18 @@ export function derive<
 >(deps: Deps, fn: (...args: Args) => V) {
     const update = () => fn(...(deps.map(d => d.value) as Args));
     const watcher = new Variable(update());
-    for (const dep of deps) dep.connect('changed', () => (watcher.value = update()));
+    const connectionIds: Array<{ emitter: Connectable; id: number }> = [];
+
+    for (const dep of deps) {
+        const id = dep.connect('changed', () => (watcher.value = update()));
+        connectionIds.push({ emitter: dep, id });
+    }
+
+    watcher.connect('dispose', () => {
+        for (const { emitter, id } of connectionIds) {
+            emitter.disconnect(id);
+        }
+    });
 
     return watcher;
 }
@@ -104,6 +126,7 @@ export function watch<T>(
     const v = new Variable(init);
     const f = typeof sigOrFn === 'function' ? sigOrFn : (callback ?? (() => v.value));
     const set = () => (v.value = f());
+    const connectionIds: Array<{ emitter: Connectable; id: number }> = [];
 
     if (Array.isArray(objs)) {
         // multiple objects
@@ -111,17 +134,26 @@ export function watch<T>(
             if (Array.isArray(obj)) {
                 // obj signal pair
                 const [o, s = 'changed'] = obj;
-                o.connect(s, set);
+                const id = o.connect(s, set);
+                connectionIds.push({ emitter: o, id });
             } else {
                 // obj on changed
-                obj.connect('changed', set);
+                const id = obj.connect('changed', set);
+                connectionIds.push({ emitter: obj, id });
             }
         }
     } else {
         // watch single object
         const signal = typeof sigOrFn === 'string' ? sigOrFn : 'changed';
-        objs.connect(signal, set);
+        const id = objs.connect(signal, set);
+        connectionIds.push({ emitter: objs, id });
     }
+
+    v.connect('dispose', () => {
+        for (const { emitter, id } of connectionIds) {
+            emitter.disconnect(id);
+        }
+    });
 
     return v.bind();
 }

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -175,14 +175,11 @@ export async function fetch(url: string, options: FetchOptions = {}) {
         );
     }
 
-    const inputStream = await session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null);
+    const gbytes = await session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null);
+    const memoryInputStream = new Gio.MemoryInputStream();
+    memoryInputStream.add_bytes(gbytes);
     const { status_code, reason_phrase } = message;
     const ok = status_code >= 200 && status_code < 300;
 
-    return new Response(
-        status_code,
-        reason_phrase,
-        ok,
-        (inputStream as unknown as Gio.InputStream) || null,
-    );
+    return new Response(status_code, reason_phrase, ok, memoryInputStream);
 }

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -8,6 +8,7 @@ import Gio from 'gi://Gio';
  * to make libsoup an optional dependency we do this
  */
 let init = false;
+let _session: any = null;
 async function libnotify() {
     try {
         import('gi://Soup?version=3.0');
@@ -21,6 +22,7 @@ async function libnotify() {
     if (init) return Soup;
 
     init = true;
+    _session = new Soup.Session();
     Gio._promisify(Soup.Session.prototype, 'send_async');
     Gio._promisify(Gio.MemoryOutputStream.prototype, 'splice_async');
     return Soup;
@@ -133,7 +135,7 @@ export async function fetch(url: string, options: FetchOptions = {}) {
         return new Response(400, 'can not fetch: missing dependency: libsoup3', false, null);
     }
 
-    const session = new Soup.Session();
+    const session = _session!;
 
     if (options.params) {
         url +=

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -24,6 +24,7 @@ async function libnotify() {
     init = true;
     _session = new Soup.Session();
     Gio._promisify(Soup.Session.prototype, 'send_async');
+    Gio._promisify(Soup.Session.prototype, 'send_and_read_async');
     Gio._promisify(Gio.MemoryOutputStream.prototype, 'splice_async');
     return Soup;
 }
@@ -174,7 +175,7 @@ export async function fetch(url: string, options: FetchOptions = {}) {
         );
     }
 
-    const inputStream = await session.send_and_read_async(message, 0, null);
+    const inputStream = await session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null);
     const { status_code, reason_phrase } = message;
     const ok = status_code >= 200 && status_code < 300;
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -132,15 +132,6 @@ export function monitorFile(
         recursive: true,
     },
 ) {
-    // FIXME: remove the checking in the next release
-    if (typeof options === 'number') {
-        console.warn(
-            `${options}` +
-                ' passed as a parameter in `options`.\n' +
-                'options parameter should be {flags: Gio.FileMonitorFlags, recursive: boolean}.',
-        );
-    }
-
     try {
         const file = Gio.File.new_for_path(path);
         const mon = file.monitor(options.flags, null);

--- a/src/widgets/box.ts
+++ b/src/widgets/box.ts
@@ -45,12 +45,28 @@ export class Box<Child extends Gtk.Widget, Attr> extends Gtk.Box {
         ...children: Gtk.Widget[]
     ) {
         const props: any = Array.isArray(propsOrChildren) ? {} : propsOrChildren;
+        const { setup, ...rest } = props;
 
-        if (Array.isArray(propsOrChildren)) props.children = propsOrChildren;
-        else if (children.length > 0) props.children = children as Child[];
+        if (Array.isArray(propsOrChildren)) rest.children = propsOrChildren;
+        else if (children.length > 0) rest.children = children as Child[];
 
-        super(props as Gtk.Box.ConstructorProps);
+        super(rest as Gtk.Box.ConstructorProps);
+
+        const self = this as any;
+        self._onHandlerIds = [];
+        this.connect('destroy', () => {
+            if (self._onHandlerIds) {
+                for (const id of self._onHandlerIds) {
+                    this.disconnect(id);
+                }
+                self._onHandlerIds = [];
+            }
+            self._set('is-destroyed', true);
+        });
+
         this.connect('notify::orientation', () => this.notify('vertical'));
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The first child widget. */

--- a/src/widgets/box.ts
+++ b/src/widgets/box.ts
@@ -69,18 +69,22 @@ export class Box<Child extends Gtk.Widget, Attr> extends Gtk.Box {
 
     set children(children: Child[]) {
         const newChildren = children || [];
+        const newSet = new Set(newChildren);
+        const oldChildren = this.get_children();
 
-        this.get_children()
-            .filter(ch => !newChildren?.includes(ch as Child))
-            .forEach(ch => ch.destroy());
-
-        // remove any children that weren't destroyed so
-        // we can re-add everything in the correct new order
-        this.get_children().forEach(ch => this.remove(ch));
+        for (const ch of oldChildren) {
+            if (!newSet.has(ch as Child)) {
+                ch.destroy();
+            } else {
+                this.remove(ch);
+            }
+        }
 
         if (!children) return;
 
-        children.forEach(w => w && this.add(w));
+        for (const w of newChildren) {
+            if (w) this.add(w);
+        }
         this.notify('children');
         this.show_all();
     }

--- a/src/widgets/button.ts
+++ b/src/widgets/button.ts
@@ -69,9 +69,10 @@ export class Button<Child extends Gtk.Widget, Attr> extends Gtk.Button {
     }
 
     constructor(props: ButtonProps<Child, Attr> = {} as ButtonProps<Child, Attr>, child?: Child) {
-        if (child) props.child = child;
+        const { setup, ...rest } = props as any;
+        if (child) rest.child = child;
 
-        super(props as Gtk.Button.ConstructorProps);
+        super(rest as Gtk.Button.ConstructorProps);
         this.add_events(Gdk.EventMask.SCROLL_MASK);
         this.add_events(Gdk.EventMask.SMOOTH_SCROLL_MASK);
 
@@ -107,6 +108,8 @@ export class Button<Child extends Gtk.Widget, Attr> extends Gtk.Button {
             if (event.get_scroll_deltas()[2] < 0) return this.on_scroll_up?.(this, event);
             else if (event.get_scroll_deltas()[2] > 0) return this.on_scroll_down?.(this, event);
         });
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The child widget inside the button. */

--- a/src/widgets/calendar.ts
+++ b/src/widgets/calendar.ts
@@ -35,11 +35,13 @@ export class Calendar<Attr> extends Gtk.Calendar {
     }
 
     constructor(props: CalendarProps<Attr> = {} as CalendarProps<Attr>) {
-        super(props as Gtk.Calendar.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.Calendar.ConstructorProps);
         this.connect('notify::day', () => this.notify('date'));
         this.connect('notify::month', () => this.notify('date'));
         this.connect('notify::year', () => this.notify('date'));
         this.connect('day-selected', this.on_day_selected.bind(this));
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The currently selected date as a tuple. */

--- a/src/widgets/centerbox.ts
+++ b/src/widgets/centerbox.ts
@@ -63,13 +63,17 @@ export class CenterBox<
         centerWidget?: CenterWidget,
         endWidget?: EndWidget,
     ) {
-        if (startWidget) props.start_widget = startWidget;
+        const { setup, ...rest } = props as any;
 
-        if (centerWidget) props.center_widget = centerWidget;
+        if (startWidget) rest.start_widget = startWidget;
 
-        if (endWidget) props.end_widget = endWidget;
+        if (centerWidget) rest.center_widget = centerWidget;
 
-        super(props as Gtk.Widget.ConstructorProps);
+        if (endWidget) rest.end_widget = endWidget;
+
+        super(rest as Gtk.Widget.ConstructorProps);
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The three slot children as a tuple: [start, center, end]. */

--- a/src/widgets/circularprogress.ts
+++ b/src/widgets/circularprogress.ts
@@ -58,9 +58,12 @@ export class CircularProgress<Child extends Gtk.Widget, Attr = unknown> extends 
         props: CircularProgressProps<Child, Attr> = {} as CircularProgressProps<Child, Attr>,
         child?: Child,
     ) {
-        if (child) props.child = child;
+        const { setup, ...rest } = props as any;
+        if (child) rest.child = child;
 
-        super(props as Gtk.Bin.ConstructorProps);
+        super(rest as Gtk.Bin.ConstructorProps);
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The child widget displayed inside the circular progress. */

--- a/src/widgets/colorbutton.ts
+++ b/src/widgets/colorbutton.ts
@@ -41,8 +41,10 @@ export class ColorButton<Child extends Gtk.Widget, Attr> extends Gtk.ColorButton
     ) {
         if (child) props.child = child;
 
-        super(props as Gtk.ColorButton.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.ColorButton.ConstructorProps);
         this.connect('color-set', this.on_color_set.bind(this));
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The child widget inside the button. */

--- a/src/widgets/drawingarea.ts
+++ b/src/widgets/drawingarea.ts
@@ -32,12 +32,14 @@ export class DrawingArea<Attr> extends Gtk.DrawingArea {
     }
 
     constructor(props: DrawingAreaProps<Attr> = {} as DrawingAreaProps<Attr>) {
-        super(props as Gtk.DrawingArea.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.DrawingArea.ConstructorProps);
         this.connect('draw', (self, cr: any) => {
             const w = this.get_allocated_width();
             const h = this.get_allocated_height();
             this.draw_fn(self, cr, w, h);
         });
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The function called on each draw with (self, cr, width, height). */

--- a/src/widgets/entry.ts
+++ b/src/widgets/entry.ts
@@ -38,10 +38,13 @@ export class Entry<Attr> extends Gtk.Entry {
     }
 
     constructor(props: EntryProps<Attr> = {} as EntryProps<Attr>) {
-        super(props as Gtk.Entry.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.Entry.ConstructorProps);
 
         this.connect('activate', () => this.on_accept?.(this));
         this.connect('notify::text', () => this.on_change?.(this));
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** Callback invoked when Enter is pressed. */

--- a/src/widgets/eventbox.ts
+++ b/src/widgets/eventbox.ts
@@ -66,9 +66,10 @@ export class EventBox<Child extends Gtk.Widget, Attr> extends Gtk.EventBox {
         props: EventBoxProps<Child, Attr> = {} as EventBoxProps<Child, Attr>,
         child?: Child,
     ) {
-        if (child) props.child = child;
+        const { setup, ...rest } = props as any;
+        if (child) rest.child = child;
 
-        super(props as Gtk.EventBox.ConstructorProps);
+        super(rest as Gtk.EventBox.ConstructorProps);
         this.add_events(Gdk.EventMask.SCROLL_MASK);
         this.add_events(Gdk.EventMask.SMOOTH_SCROLL_MASK);
 
@@ -110,6 +111,8 @@ export class EventBox<Child extends Gtk.Widget, Attr> extends Gtk.EventBox {
             if (event.get_scroll_deltas()[2] < 0) return this.on_scroll_up?.(this, event);
             else if (event.get_scroll_deltas()[2] > 0) return this.on_scroll_down?.(this, event);
         });
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The child widget inside the event box. */

--- a/src/widgets/filechooserbutton.ts
+++ b/src/widgets/filechooserbutton.ts
@@ -41,8 +41,10 @@ export class FileChooserButton<Child extends Gtk.Widget, Attr> extends Gtk.FileC
     ) {
         if (child) props.child = child;
 
-        super(props as Gtk.FileChooserButton.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.FileChooserButton.ConstructorProps);
         this.connect('file-set', this.on_file_set.bind(this));
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The child widget inside the button. */

--- a/src/widgets/fixed.ts
+++ b/src/widgets/fixed.ts
@@ -23,7 +23,9 @@ export class Fixed<Attr> extends Gtk.Fixed {
     }
 
     constructor(props: FixedProps<Attr> = {} as FixedProps<Attr>) {
-        super(props as Gtk.Fixed.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.Fixed.ConstructorProps);
+        if (typeof setup === 'function') setup(this);
     }
 }
 

--- a/src/widgets/flowbox.ts
+++ b/src/widgets/flowbox.ts
@@ -23,7 +23,9 @@ export class FlowBox<Attr> extends Gtk.FlowBox {
     }
 
     constructor(props: FlowBoxProps<Attr> = {} as FlowBoxProps<Attr>) {
-        super(props as Gtk.FlowBox.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.FlowBox.ConstructorProps);
+        if (typeof setup === 'function') setup(this);
     }
 }
 

--- a/src/widgets/fontbutton.ts
+++ b/src/widgets/fontbutton.ts
@@ -41,8 +41,10 @@ export class FontButton<Child extends Gtk.Widget, Attr> extends Gtk.FontButton {
     ) {
         if (child) props.child = child;
 
-        super(props as Gtk.FontButton.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.FontButton.ConstructorProps);
         this.connect('font-set', this.on_font_set.bind(this));
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The child widget inside the button. */

--- a/src/widgets/icon.ts
+++ b/src/widgets/icon.ts
@@ -36,7 +36,7 @@ export class Icon<Attr> extends Gtk.Image {
     }
 
     constructor(props: IconProps<Attr> | Ico = {} as IconProps<Attr>) {
-        const { icon = '', ...rest } = props as IconProps<Attr>;
+        const { icon = '', setup, ...rest } = props as any;
         super(
             typeof props === 'string' || props instanceof GdkPixbuf.Pixbuf
                 ? {}
@@ -48,6 +48,8 @@ export class Icon<Attr> extends Gtk.Image {
             'icon',
             typeof props === 'string' || props instanceof GdkPixbuf.Pixbuf ? props : icon,
         );
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The pixel size of the icon, falls back to CSS font-size. */

--- a/src/widgets/label.ts
+++ b/src/widgets/label.ts
@@ -53,12 +53,14 @@ export class Label<Attr> extends Gtk.Label {
     }
 
     constructor(props: LabelProps<Attr> | string = {} as LabelProps<Attr>) {
-        const { label, ...config } = props as Gtk.Label.ConstructorProps;
+        const { label, setup, ...config } = props as any;
         const text = typeof props === 'string' ? props : label;
         super(typeof props === 'string' ? {} : config);
         this._handleParamProp('label', text || '');
         this.connect('notify::justify', () => this.notify('justification'));
         this.connect('notify::ellipsize', () => this.notify('truncate'));
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The displayed text. Invalid markup is escaped automatically when use_markup is enabled. */

--- a/src/widgets/levelbar.ts
+++ b/src/widgets/levelbar.ts
@@ -33,9 +33,11 @@ export class LevelBar<Attr> extends Gtk.LevelBar {
     }
 
     constructor(props: LevelBarProps<Attr> = {} as LevelBarProps<Attr>) {
-        super(props as Gtk.LevelBar.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.LevelBar.ConstructorProps);
         this.connect('notify::mode', () => this.notify('bar-mode'));
         this.connect('notify::orientation', () => this.notify('vertical'));
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The bar display mode: 'continuous' or 'discrete'. */

--- a/src/widgets/listbox.ts
+++ b/src/widgets/listbox.ts
@@ -21,7 +21,9 @@ export class ListBox<Attr> extends Gtk.ListBox {
     }
 
     constructor(props: ListBoxProps<Attr> = {} as ListBoxProps<Attr>) {
-        super(props as Gtk.ListBox.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.ListBox.ConstructorProps);
+        if (typeof setup === 'function') setup(this);
     }
 }
 

--- a/src/widgets/menu.ts
+++ b/src/widgets/menu.ts
@@ -52,10 +52,12 @@ export class Menu<MenuItem extends Gtk.MenuItem, Attr> extends Gtk.Menu {
     ) {
         if (children.length > 0) props.children = children as MenuItem[];
 
-        super(props as Gtk.Menu.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.Menu.ConstructorProps);
 
         this.connect('popped-up', (_, ...args) => this.on_popup?.(this, ...args));
         this.connect('move-scroll', (_, ...args) => this.on_move_scroll?.(this, ...args));
+        if (typeof setup === 'function') setup(this);
     }
 
     /** Callback invoked when the menu is popped up. */

--- a/src/widgets/menubar.ts
+++ b/src/widgets/menubar.ts
@@ -21,7 +21,9 @@ export class MenuBar<Attr> extends Gtk.MenuBar {
     }
 
     constructor(props: MenuBarProps<Attr> = {} as MenuBarProps<Attr>) {
-        super(props as Gtk.MenuBar.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.MenuBar.ConstructorProps);
+        if (typeof setup === 'function') setup(this);
     }
 }
 

--- a/src/widgets/menuitem.ts
+++ b/src/widgets/menuitem.ts
@@ -45,11 +45,13 @@ export class MenuItem<Child extends Gtk.Widget, Attr> extends Gtk.MenuItem {
     ) {
         if (child) props.child = child;
 
-        super(props as Gtk.MenuItem.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.MenuItem.ConstructorProps);
 
         this.connect('activate', () => this.on_activate?.(this));
         this.connect('select', () => this.on_select?.(this));
         this.connect('deselect', () => this.on_deselect?.(this));
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The child widget of this menu item. */

--- a/src/widgets/overlay.ts
+++ b/src/widgets/overlay.ts
@@ -51,11 +51,14 @@ export class Overlay<Child extends Gtk.Widget, OverlayChild extends Gtk.Widget, 
         child?: Child,
         ...overlays: Gtk.Widget[]
     ) {
-        if (child) props.child = child;
+        const { setup, ...rest } = props as any;
+        if (child) rest.child = child;
 
-        if (overlays.length > 0) props.overlays = overlays as OverlayChild[];
+        if (overlays.length > 0) rest.overlays = overlays as OverlayChild[];
 
-        super(props as Gtk.Overlay.ConstructorProps);
+        super(rest as Gtk.Overlay.ConstructorProps);
+
+        if (typeof setup === 'function') setup(this);
     }
 
     private _updatePassThrough() {

--- a/src/widgets/progressbar.ts
+++ b/src/widgets/progressbar.ts
@@ -31,9 +31,12 @@ export class ProgressBar<Attr> extends Gtk.ProgressBar {
     }
 
     constructor(props: ProgressBarProps<Attr> = {} as ProgressBarProps<Attr>) {
-        super(props as Gtk.ProgressBar.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.ProgressBar.ConstructorProps);
         this.connect('notify::fraction', () => this.notify('value'));
         this.connect('notify::orientation', () => this.notify('vertical'));
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The progress value, an alias for the underlying `fraction` property. */

--- a/src/widgets/revealer.ts
+++ b/src/widgets/revealer.ts
@@ -55,10 +55,13 @@ export class Revealer<Child extends Gtk.Widget, Attr> extends Gtk.Revealer {
         props: RevealerProps<Child, Attr> = {} as RevealerProps<Child, Attr>,
         child?: Child,
     ) {
-        if (child) props.child = child;
+        const { setup, ...rest } = props as any;
+        if (child) rest.child = child;
 
-        super(props as Gtk.Revealer.ConstructorProps);
+        super(rest as Gtk.Revealer.ConstructorProps);
         this.connect('notify::transition-type', () => this.notify('transition'));
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The child widget to reveal or hide. */

--- a/src/widgets/scrollable.ts
+++ b/src/widgets/scrollable.ts
@@ -57,10 +57,11 @@ export class Scrollable<Child extends Gtk.Widget, Attr> extends Gtk.ScrolledWind
         props: ScrollableProps<Child, Attr> = {} as ScrollableProps<Child, Attr>,
         child?: Child,
     ) {
-        if (child) props.child = child;
+        const { setup, ...rest } = props as any;
+        if (child) rest.child = child;
 
         super({
-            ...(props as Gtk.ScrolledWindow.ConstructorProps),
+            ...(rest as Gtk.ScrolledWindow.ConstructorProps),
             hadjustment: new Gtk.Adjustment(),
             vadjustment: new Gtk.Adjustment(),
         });
@@ -68,6 +69,8 @@ export class Scrollable<Child extends Gtk.Widget, Attr> extends Gtk.ScrolledWind
         this.connect('destroy', () => {
             if (this.child instanceof Gtk.Viewport) this.child.child.destroy();
         });
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The scrollable content child widget. */

--- a/src/widgets/separator.ts
+++ b/src/widgets/separator.ts
@@ -29,8 +29,10 @@ export class Separator<Attr> extends Gtk.Separator {
     }
 
     constructor(props: SeparatorProps<Attr> = {} as SeparatorProps<Attr>) {
-        super(props as Gtk.Separator.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.Separator.ConstructorProps);
         this.connect('notify::orientation', () => this.notify('vertical'));
+        if (typeof setup === 'function') setup(this);
     }
 
     /** Whether the separator is oriented vertically. */

--- a/src/widgets/slider.ts
+++ b/src/widgets/slider.ts
@@ -69,6 +69,7 @@ export class Slider<Attr> extends Gtk.Scale {
             max = 1,
             step = 0.01,
             marks = [],
+            setup,
             ...rest
         }: SliderProps<Attr> = {} as SliderProps<Attr>,
     ) {
@@ -88,6 +89,8 @@ export class Slider<Attr> extends Gtk.Scale {
 
             this.on_change?.(this, event);
         });
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** Callback invoked when the slider value changes during user interaction. */

--- a/src/widgets/slider.ts
+++ b/src/widgets/slider.ts
@@ -200,12 +200,11 @@ export class Slider<Attr> extends Gtk.Scale {
     }
 
     vfunc_scroll_event(event: Gdk.EventScroll): boolean {
-        this.dragging = true;
+        this._set('dragging', true, false);
         event.delta_y > 0
             ? (this.adjustment.value -= this.step)
             : (this.adjustment.value += this.step);
-
-        this.dragging = false;
+        this._set('dragging', false, false);
         return super.vfunc_scroll_event(event);
     }
 }

--- a/src/widgets/spinbutton.ts
+++ b/src/widgets/spinbutton.ts
@@ -35,8 +35,10 @@ export class SpinButton<Attr> extends Gtk.SpinButton {
     }
 
     constructor(props: SpinButtonProps<Attr> = {} as SpinButtonProps<Attr>) {
-        super(props as Gtk.SpinButton.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.SpinButton.ConstructorProps);
         this.connect('value-changed', this.on_value_changed.bind(this));
+        if (typeof setup === 'function') setup(this);
     }
 
     /** Callback invoked when the spin button value changes. */

--- a/src/widgets/spinner.ts
+++ b/src/widgets/spinner.ts
@@ -27,11 +27,13 @@ export class Spinner<Attr> extends Gtk.Spinner {
             Attr
         >,
     ) {
-        super(props as Gtk.Widget.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.Widget.ConstructorProps);
         this.start();
         this.connect('notify::visible', ({ visible }) => {
             visible ? this.start() : this.stop();
         });
+        if (typeof setup === 'function') setup(this);
     }
 }
 

--- a/src/widgets/stack.ts
+++ b/src/widgets/stack.ts
@@ -70,10 +70,13 @@ export class Stack<Children extends { [name: string]: Gtk.Widget }, Attr> extend
         props: StackProps<Children, Attr> = {} as StackProps<Children, Attr>,
         children?: Children,
     ) {
-        if (children) props.children = children;
+        const { setup, ...rest } = props as any;
+        if (children) rest.children = children;
 
-        super(props as Gtk.Stack.ConstructorProps);
+        super(rest as Gtk.Stack.ConstructorProps);
         this.connect('notify::visible-child-name', () => this.notify('shown'));
+
+        if (typeof setup === 'function') setup(this);
     }
 
     add_named(child: Gtk.Widget, name: string): void {

--- a/src/widgets/switch.ts
+++ b/src/widgets/switch.ts
@@ -29,8 +29,10 @@ export class Switch<Attr> extends Gtk.Switch {
     }
 
     constructor(props: SwitchProps<Attr> = {} as SwitchProps<Attr>) {
-        super(props as Gtk.Switch.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.Switch.ConstructorProps);
         this.connect('notify::active', this.on_activate.bind(this));
+        if (typeof setup === 'function') setup(this);
     }
 
     /** Callback invoked when the switch is toggled. */

--- a/src/widgets/togglebutton.ts
+++ b/src/widgets/togglebutton.ts
@@ -41,8 +41,10 @@ export class ToggleButton<Child extends Gtk.Widget, Attr> extends Gtk.ToggleButt
     ) {
         if (child) props.child = child;
 
-        super(props as Gtk.ToggleButton.ConstructorProps);
+        const { setup, ...rest } = props as any;
+        super(rest as Gtk.ToggleButton.ConstructorProps);
         this.connect('toggled', this.on_toggled.bind(this));
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The child widget of this toggle button. */

--- a/src/widgets/widget.ts
+++ b/src/widgets/widget.ts
@@ -306,6 +306,7 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
     }
 
     on(signal: string, callback: (self: this, ...args: any[]) => void): this {
+        if (!this._onHandlerIds) this._onHandlerIds = [];
         const id = this.connect(signal, callback);
         this._onHandlerIds.push(id);
         return this;
@@ -372,10 +373,12 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
         );
 
         this.connect('destroy', () => {
-            for (const id of this._onHandlerIds) {
-                this.disconnect(id);
+            if (this._onHandlerIds) {
+                for (const id of this._onHandlerIds) {
+                    this.disconnect(id);
+                }
+                this._onHandlerIds = [];
             }
-            this._onHandlerIds = [];
             this._set('is-destroyed', true);
         });
 
@@ -585,6 +588,7 @@ export function register<T extends { new (...args: any[]): Gtk.Widget }>(
             Object.getOwnPropertyDescriptor(AgsWidget.prototype, name) || Object.create(null),
         );
     });
+
     return registerGObject(klass, {
         cssName: config?.cssName,
         typename: config?.typename || `Ags_${klass.name}`,

--- a/src/widgets/widget.ts
+++ b/src/widgets/widget.ts
@@ -7,19 +7,6 @@ import { Props, BindableProps, Binding, Connectable } from '../service.js';
 import { registerGObject, kebabify, type CtorProps } from '../utils/gobject.js';
 import { interval, idle } from '../utils.js';
 
-let warned = false;
-function deprecated() {
-    if (warned) return;
-
-    console.warn(
-        Error(
-            'Using "connections" and "binds" props are DEPRECATED\n' +
-                'Use .hook() .bind() .poll() .on() instead, refer to the wiki to see examples',
-        ),
-    );
-    warned = true;
-}
-
 /** @internal Map of alignment string names to GTK Align enum values. */
 const ALIGN = {
     fill: Gtk.Align.FILL,
@@ -28,6 +15,8 @@ const ALIGN = {
     center: Gtk.Align.CENTER,
     baseline: Gtk.Align.BASELINE,
 } as const;
+
+const ALIGN_KEYS = new Set(Object.keys(ALIGN));
 
 /** String alignment values: `'fill'`, `'start'`, `'end'`, `'center'`, `'baseline'`. */
 type Align = keyof typeof ALIGN;
@@ -78,15 +67,6 @@ type Cursor =
     | 'nwse-resize'
     | 'zoom-in'
     | 'zoom-out';
-
-type Property = [prop: string, value: unknown];
-
-type Connection<Self> =
-    | [GObject.Object, (self: Self, ...args: unknown[]) => unknown, string?]
-    | [string, (self: Self, ...args: unknown[]) => unknown]
-    | [number, (self: Self, ...args: unknown[]) => unknown];
-
-type Bind = [prop: string, obj: GObject.Object, objProp?: string, transform?: (value: any) => any];
 
 /**
  * Common properties available on all AGS widgets.
@@ -263,6 +243,9 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
         return this._get('attribute');
     }
 
+    _onHandlerIds: number[] = [];
+    _cursorHandlersConnected = false;
+
     hook(
         gobject: Connectable,
         callback: (self: this, ...args: any[]) => void,
@@ -323,7 +306,8 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
     }
 
     on(signal: string, callback: (self: this, ...args: any[]) => void): this {
-        this.connect(signal, callback);
+        const id = this.connect(signal, callback);
+        this._onHandlerIds.push(id);
         return this;
     }
 
@@ -386,12 +370,13 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
             },
         );
 
-        this.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK);
-        this.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK);
-
-        this.connect('enter-notify-event', this._updateCursor.bind(this));
-        this.connect('leave-notify-event', this._updateCursor.bind(this));
-        this.connect('destroy', () => this._set('is-destroyed', true));
+        this.connect('destroy', () => {
+            for (const id of this._onHandlerIds) {
+                this.disconnect(id);
+            }
+            this._onHandlerIds = [];
+            this._set('is-destroyed', true);
+        });
 
         idle(() => {
             if (this.click_through && !this.is_destroyed)
@@ -429,57 +414,10 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
         if (notify) this.notify(field);
     }
 
-    /** @deprecated Use `.hook()`, `.bind()`, `.poll()`, `.on()` instead. */
-    set connections(connections: Connection<this>[]) {
-        if (!connections) return;
-
-        deprecated();
-        connections.forEach(([s, callback, event]) => {
-            if (s === undefined || callback === undefined)
-                return console.error(Error('missing arguments to connections'));
-
-            if (typeof s === 'string') this.connect(s, callback);
-            else if (typeof s === 'number') interval(s, () => callback(this), this);
-            else if (s instanceof GObject.Object) this.hook(s, callback, event);
-            else console.error(Error(`${s} is not a GObject | string | number`));
-        });
-    }
-
-    /** @deprecated Use `.bind()` method instead. */
-    set binds(binds: Bind[]) {
-        if (!binds) return;
-
-        deprecated();
-        binds.forEach(([prop, obj, objProp = 'value', transform = out => out]) => {
-            // @ts-expect-error
-            this.bind(prop, obj, objProp, transform);
-        });
-    }
-
-    /** @deprecated Use `attribute` instead. */
-    set properties(properties: Property[]) {
-        if (!properties) return;
-
-        console.warn(Error('"properties" is deprecated use "attribute" instead'));
-        properties.forEach(([key, value]) => {
-            (this as unknown as { [key: string]: unknown })[`_${key}`] = value;
-        });
-    }
-
-    /** @deprecated Renamed to {@link hook}. */
-    connectTo<GObject extends GObject.Object>(
-        gobject: GObject,
-        callback: (self: this, ...args: any[]) => void,
-        signal?: string,
-    ) {
-        console.warn(Error('connectTo was renamed to hook'));
-        return this.hook(gobject, callback, signal);
-    }
-
     _setPack(orientation: 'h' | 'v', align: Align) {
         if (!align) return;
 
-        if (!Object.keys(ALIGN).includes(align)) {
+        if (!ALIGN_KEYS.has(align)) {
             return console.error(
                 Error(
                     `${orientation}pack has to be on of ${Object.keys(ALIGN)}, but it is ${align}`,
@@ -514,12 +452,14 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
         this._setPack('v', align);
     }
 
-    toggleClassName(className: string, condition = true) {
+    toggleClassName(className: string, condition = true, notify = true) {
         const c = this.get_style_context();
         condition ? c.add_class(className) : c.remove_class(className);
 
-        this.notify('class-names');
-        this.notify('class-name');
+        if (notify) {
+            this.notify('class-names');
+            this.notify('class-name');
+        }
     }
 
     /** Space-separated CSS class names. */
@@ -537,8 +477,10 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
     }
 
     set class_names(names: string[]) {
-        this.class_names.forEach((cn: string) => this.toggleClassName(cn, false));
-        names.forEach(cn => this.toggleClassName(cn));
+        this.class_names.forEach((cn: string) => this.toggleClassName(cn, false, false));
+        names.forEach(cn => this.toggleClassName(cn, true, false));
+        this.notify('class-names');
+        this.notify('class-name');
     }
 
     _cssProvider!: Gtk.CssProvider;
@@ -586,6 +528,15 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
 
     set cursor(cursor: Cursor) {
         this._set('cursor', cursor);
+
+        if (cursor && !this._cursorHandlersConnected) {
+            this._cursorHandlersConnected = true;
+            this.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK);
+            this.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK);
+            this.connect('enter-notify-event', this._updateCursor.bind(this));
+            this.connect('leave-notify-event', this._updateCursor.bind(this));
+        }
+
         this._updateCursor();
     }
 
@@ -648,17 +599,6 @@ export function register<T extends { new (...args: any[]): Gtk.Widget }>(
             'is-destroyed': ['boolean', 'r'],
             attribute: ['jsobject', 'rw'],
             'click-through': ['boolean', 'rw'],
-
-            // FIXME: deprecated
-            properties: ['jsobject', 'w'],
-            connections: ['jsobject', 'w'],
-            binds: ['jsobject', 'w'],
         },
     });
 }
-
-/** @deprecated Backwards compatibility export. Use {@link register} instead. */
-export default function W(klass: any) {
-    return klass;
-}
-W.register = register;

--- a/src/widgets/widget.ts
+++ b/src/widgets/widget.ts
@@ -346,6 +346,7 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
         > = {} as any,
         child?: Gtk.Widget,
     ) {
+        this._onHandlerIds = [];
         const { setup, attribute, ...props } = config || {};
 
         const binds = (Object.keys(props) as Array<keyof typeof props>)

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -110,6 +110,7 @@ export class Window<Child extends Gtk.Widget, Attr> extends Gtk.Window {
             gdkmonitor,
             popup = false,
             visible = true,
+            setup,
             ...params
         }: WindowProps<Child, Attr> = {} as WindowProps<Child, Attr>,
         child?: Child,
@@ -117,6 +118,19 @@ export class Window<Child extends Gtk.Widget, Attr> extends Gtk.Window {
         if (child) params.child = child;
 
         super(params as unknown as Gtk.Window.ConstructorProps);
+
+        const self = this as any;
+        self._onHandlerIds = [];
+        this.connect('destroy', () => {
+            if (self._onHandlerIds) {
+                for (const id of self._onHandlerIds) {
+                    this.disconnect(id);
+                }
+                self._onHandlerIds = [];
+            }
+            self._set('is-destroyed', true);
+        });
+
         LayerShell.init_for_window(this);
         LayerShell.set_namespace(this, this.name);
 
@@ -135,6 +149,8 @@ export class Window<Child extends Gtk.Widget, Attr> extends Gtk.Window {
 
         if (visible instanceof Binding) this._handleParamProp('visible', visible);
         else this.visible = visible === true || (visible === null && !popup);
+
+        if (typeof setup === 'function') setup(this);
     }
 
     /** The child widget of this window. */
@@ -143,7 +159,12 @@ export class Window<Child extends Gtk.Widget, Attr> extends Gtk.Window {
     }
 
     set child(child: Child) {
-        super.child = child;
+        const old = this.get_child();
+        if (old && old !== child) this.remove(old);
+        if (child) {
+            this.add(child);
+            child.show();
+        }
     }
 
     /** The GDK monitor this window is assigned to. */


### PR DESCRIPTION
I think now is a great time to address all deprecations Aylur has envisioned before dropping v1 and moving on to v2, which was a major paradigm shift. Since our goal is a clean codebase that is maintainable, it's about time I've addressed all deprecations. This PR is that; introduces several improvements across the codebase, generally focusing on event bindings and code simplification for mantainability and performance. I've improved cleanup of event listeners and property update logic for less memory leaks (born to malloc, forced to free). Minor breakages to be expected.



Change-Id: I628547ade474dfec1d0a14926d62ed676a6a6964