### PR TITLE
services: add lockscreen and polkit integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # RAGS Changelog
 
+## Unreleased
+
+### Added
+
+- `lockscreen` service for secure Wayland `ext-session-lock-v1` session locking
+  through the `gtk-session-lock` library
+- `polkit` service for registering RAGS as a Polkit authentication agent
+
 ## 1.11.0
 
 This release represents a comprehensive refactoring of the RAGS codebase,
@@ -56,6 +64,8 @@ services the users may need to update. See below for a full list of changes.
 - App: Fixed deprecation warnings (`cacheCoverArt` to `maxStreamVolume`)
 - Fetch: Wrapped `GBytes` from `send_and_read_async` in `MemoryInputStream`
 - GJS shebang launcher replaced with a compiled C binary entrypoint
+- Build/package dependencies now include `gtk-session-lock` and Polkit agent
+  libraries for the new lockscreen and Polkit services
 - Hyprland: remaining IPC events supported; IPC commands serialized with socket
   failure handling
 - `utils/file` returns an error when file read fails instead of swallowing it

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@
 
 - Utility GObject based library in c
   - [x] pam module [#273](https://github.com/Aylur/ags/pull/273)
-  - [ ] ext-session-lock
+  - [x] ext-session-lock
 - [x] fetch util function [#187](https://github.com/Aylur/ags/pull/187)
 - [x] toJSON overridies [#203](https://github.com/Aylur/ags/pull/203)
 - [ ] Circular slider widget

--- a/docs/guides/configuration/06-services.md
+++ b/docs/guides/configuration/06-services.md
@@ -104,3 +104,5 @@ import { battery } from "resource:///com/github/Aylur/ags/service/battery.js";
 - [notifications](../services/10-notifications.md)
 - [powerprofiles](../services/11-powerprofiles.md)
 - [systemtray](../services/12-systemtray.md)
+- [lockscreen](../services/13-lockscreen.md)
+- [polkit](../services/14-polkit.md)

--- a/docs/guides/getting-started/01-installation.md
+++ b/docs/guides/getting-started/01-installation.md
@@ -22,15 +22,20 @@ available in your PATH.
 ### Installing with `nix profile`
 
 ```bash
-nix profile install github:Aylur/ags
+# Get RAGS from GitHub using `nix profile`. Unlike the NixOS module this does
+# not provide the necessary integrations, e.g., PAM so you must handle those
+# manually per your distribution.
+$ nix profile install github:notashelf/rags
 ```
 
 ### Single run with `nix run`
 
-or try it without installing
+You may also run RAGS without installing, and have it removed on the next
+garbage collection. Simply run with `nix run`:
 
 ```bash
-nix run github:Aylur/ags
+# Fetch, unpack and build RAGS. Then run it from the Nix storeç
+$ nix run github:notashelf/rags
 ```
 
 ### Installing Permanently
@@ -58,30 +63,31 @@ An example installation for Home Manager is provided over at the
 
 ```bash
 # Arch
-sudo pacman -S typescript npm meson gjs gtk3 gtk-layer-shell gnome-bluetooth-3.0 upower networkmanager gobject-introspection libdbusmenu-gtk3 libsoup3
+sudo pacman -S typescript npm meson gjs gtk3 gtk-layer-shell gtk-session-lock gnome-bluetooth-3.0 upower networkmanager gobject-introspection libdbusmenu-gtk3 libsoup3 polkit
 ```
 
 ```bash
 # Fedora
-sudo dnf install typescript npm meson gjs-devel gtk3-devel gtk-layer-shell gnome-bluetooth upower NetworkManager pulseaudio-libs-devel libdbusmenu-gtk3 libsoup3
+sudo dnf install typescript npm meson gjs-devel gtk3-devel gtk-layer-shell-devel gtk-session-lock-devel gnome-bluetooth upower NetworkManager pulseaudio-libs-devel libdbusmenu-gtk3 libsoup3 polkit-devel
 ```
 
 ```bash
 # Ubuntu
-sudo apt install node-typescript npm meson libgjs-dev gjs libgtk-layer-shell-dev libgtk-3-dev libpulse-dev network-manager-dev libgnome-bluetooth-3.0-dev libdbusmenu-gtk3-dev libsoup-3.0-dev
+sudo apt install node-typescript npm meson libgjs-dev gjs libgtk-layer-shell-dev libgtk-session-lock-dev libgtk-3-dev libpulse-dev network-manager-dev libgnome-bluetooth-3.0-dev libdbusmenu-gtk3-dev libsoup-3.0-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev
 ```
 
 ```bash
-# clone, build, install
-git clone --recursive https://github.com/Aylur/ags.git
-cd ags
-npm install
-meson setup build
-meson install -C build
+# Clone, build, and  install
+$ git clone --recursive https://github.com/Aylur/ags.git && cd ags
+$ pnpm install
+$ meson setup build
+$ meson install -C build
 ```
 
 ## Running
 
 ```bash
-ags --help
+# RAGS provides `ags` as the main binary for compatibility. This may change
+# in the future.
+$ ags --help
 ```

--- a/docs/guides/services/13-lockscreen.md
+++ b/docs/guides/services/13-lockscreen.md
@@ -1,0 +1,83 @@
+---
+title: Lockscreen
+description: Secure Wayland session-lock integration
+category: Guides
+group: Services
+---
+
+The `lockscreen` service wraps the Wayland `ext-session-lock-v1` protocol
+through the `gtk-session-lock` library. RAGS owns the lock surfaces; it does not
+launch a separate locker program.
+
+## Setup
+
+Build RAGS with the `gtk-session-lock` library available, and run it under a
+compositor that supports `ext-session-lock-v1`. For password unlocks, the
+service uses the existing PAM utility:
+
+```nix
+security.pam.services.ags = {};
+```
+
+Under NixOS `gtk-session-lock` is a part of the RAGS packaging. Other
+distributions may need to install it manually.
+
+## Example
+
+```js
+import Gtk from "gi://Gtk?version=3.0";
+
+const lockscreen = await Service.import("lockscreen");
+
+function Surface(monitor, index) {
+  const entry = Widget.Entry({
+    visibility: false,
+    on_accept: async (self) => {
+      try {
+        await lockscreen.unlockWithPassword(self.text);
+      } catch (error) {
+        self.text = "";
+        logError(error, "unlock failed");
+      }
+    },
+  });
+
+  return new Gtk.Window({
+    name: `lock-${index}`,
+    child: Widget.Box({
+      vertical: true,
+      vpack: "center",
+      hpack: "center",
+      children: [
+        Widget.Label({ label: "Locked" }),
+        entry,
+      ],
+    }),
+  });
+}
+
+lockscreen.lock(Surface);
+```
+
+## API
+
+### Properties
+
+- `available`: `boolean` - whether session-lock is supported.
+- `locked`: `boolean` - whether the current lock is active.
+- `protocol_version`: `number` - compositor protocol version, or `0`.
+
+### Methods
+
+- `refresh()` updates `available` and `protocol_version`.
+- `lock(factory)` locks the session and creates one surface per monitor.
+- `unlock()` unlocks an active lock. Call this only after authentication.
+- `unlockWithPassword(password, username?, service?)` authenticates with PAM and
+  unlocks. The default PAM service is `ags`.
+- `cancel()` cancels a lock that has not become active yet.
+
+### Signals
+
+- `locked` fires when the compositor confirms the lock.
+- `unlocked` fires when `unlock()` is called.
+- `finished` fires when the lock object is no longer active.

--- a/docs/guides/services/14-polkit.md
+++ b/docs/guides/services/14-polkit.md
@@ -1,0 +1,104 @@
+---
+title: Polkit
+description: Polkit authentication agent integration
+category: Guides
+group: Services
+---
+
+The `polkit` service registers RAGS as a polkit authentication agent for the
+current user session.
+
+The sensitive part of the flow is implemented in the native `GUtils` helper: it
+subclasses `PolkitAgent.Listener` and uses `PolkitAgent.Session`, which
+delegates successful responses through polkit's setuid helper. JavaScript code
+only receives request metadata and sends prompt responses.
+
+## Example
+
+```js
+const polkit = await Service.import("polkit");
+
+const password = Widget.Entry({
+  visibility: false,
+  on_accept: (self) => {
+    polkit.respond(self.text);
+    self.text = "";
+  },
+});
+
+const dialog = Widget.Window({
+  name: "polkit",
+  layer: "overlay",
+  keymode: "exclusive",
+  visible: polkit.bind("active"),
+  child: Widget.Box({
+    vertical: true,
+    children: [
+      Widget.Label({
+        label: polkit.bind("current-request").as((request) => {
+          return request?.message ?? "";
+        }),
+      }),
+      Widget.Label({
+        label: polkit.bind("prompt").as((prompt) => {
+          return prompt?.message ?? "";
+        }),
+      }),
+      password,
+      Widget.Button({
+        label: "Cancel",
+        on_clicked: () => polkit.cancel(),
+      }),
+    ],
+  }),
+});
+
+polkit.connect(
+  "request",
+  () => Utils.timeout(100, () => password.grab_focus()),
+);
+polkit.connect("show-error", (_, message) => print(message));
+polkit.registerAgent();
+```
+
+## Identity Selection
+
+By default, the service selects the first identity polkit offers. Disable this
+if your UI lets the user choose an identity:
+
+```js
+polkit.autoSelectIdentity = false;
+polkit.connect("begin", (_, request) => {
+  request.identities.forEach((identity, index) => {
+    print(`${index}: ${identity.name ?? identity.id}`);
+  });
+});
+
+polkit.selectIdentity(0);
+```
+
+## API
+
+### Properties
+
+- `registered`: `boolean` - whether this process is registered as an agent.
+- `active`: `boolean` - whether an authentication request is active.
+- `current_request`: object or `null` - action id, message, details, and
+  identities.
+- `prompt`: object or `null` - prompt message and whether echo is allowed.
+
+### Methods
+
+- `registerAgent(options?)` registers the current process as an agent.
+- `unregisterAgent()` unregisters the agent.
+- `selectIdentity(index)` starts authentication for an offered identity.
+- `respond(response)` answers the current prompt.
+- `cancel()` cancels the current authentication request.
+
+### Signals
+
+- `begin(request)` fires when polkit starts an authentication request.
+- `request(prompt)` fires when PAM asks for input.
+- `show-info(message)` and `show-error(message)` forward PAM messages.
+- `completed(authorized)` fires when the authentication session ends.
+- `cancelled` fires when polkit or the user cancels the request.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,8 @@ here if you are new to RAGS.
 - **Advanced** - Writing custom services, subclassing GTK widgets, common
   issues, and example configurations.
 - **Services** - Reference pages for each built-in service: Applications, Audio,
-  Backlight, Battery, Bluetooth, Greetd, Hyprland, MPRIS, Network,
-  Notifications, Power Profiles, and System Tray.
+  Backlight, Battery, Bluetooth, Greetd, Hyprland, Lockscreen, MPRIS, Network,
+  Notifications, Polkit, Power Profiles, and System Tray.
 
 ### API Reference
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,8 +34,11 @@ export default [
             globals: {
                 pkg: 'readonly',
                 ARGV: 'readonly',
+                App: 'readonly',
                 Debugger: 'readonly',
                 GIRepositoryGType: 'readonly',
+                Variable: 'readonly',
+                Widget: 'readonly',
                 globalThis: 'readonly',
                 imports: 'readonly',
                 Intl: 'readonly',

--- a/example/lockscreen/README.md
+++ b/example/lockscreen/README.md
@@ -1,0 +1,16 @@
+# Lockscreen Example
+
+This config demonstrates only the `lockscreen` service.
+
+Requirements:
+
+- A Wayland compositor with `ext-session-lock-v1` support.
+- RAGS built with the `gtk-session-lock` library available to GJS.
+- A PAM service that accepts local password authentication. This example uses
+  `login` so it can be tested without adding `/etc/pam.d/ags` first.
+
+Run with:
+
+```sh
+ags --config example/lockscreen/config.js
+```

--- a/example/lockscreen/config.js
+++ b/example/lockscreen/config.js
@@ -1,0 +1,73 @@
+import Gtk from "gi://Gtk?version=3.0"
+
+const lockscreen = await Service.import("lockscreen")
+
+const password = Variable("")
+const unlockError = Variable("")
+
+function LockSurface(_monitor, index) {
+    const entry = Widget.Entry({
+        visibility: false,
+        placeholder_text: "Password",
+        text: password.bind(),
+        on_change: ({ text }) => password.value = text,
+        on_accept: async () => {
+            try {
+                await lockscreen.unlockWithPassword(password.value, undefined, "login")
+                password.value = ""
+                unlockError.value = ""
+            } catch (error) {
+                password.value = ""
+                unlockError.value = "Authentication failed"
+                logError(error, "unlock failed")
+            }
+        },
+    })
+
+    return new Gtk.Window({
+        name: `lock-${index}`,
+        child: Widget.Box({
+            vertical: true,
+            hpack: "center",
+            vpack: "center",
+            class_name: "lock-card",
+            children: [
+                Widget.Label({
+                    class_name: "lock-title",
+                    label: "Session Locked",
+                }),
+                entry,
+                Widget.Label({
+                    class_name: "error",
+                    visible: unlockError.bind().as(Boolean),
+                    label: unlockError.bind(),
+                }),
+            ],
+            setup: () => Utils.timeout(100, () => entry.grab_focus()),
+        }),
+    })
+}
+
+function LockButton() {
+    return Widget.Window({
+        name: "lock-button",
+        anchor: ["top", "right"],
+        margins: [12, 12],
+        child: Widget.Button({
+            class_name: "lock-button",
+            label: "Lock",
+            on_clicked: () => {
+                try {
+                    lockscreen.lock(LockSurface)
+                } catch (error) {
+                    logError(error, "session-lock unavailable")
+                }
+            },
+        }),
+    })
+}
+
+App.config({
+    style: App.configDir + "/style.css",
+    windows: [LockButton()],
+})

--- a/example/lockscreen/style.css
+++ b/example/lockscreen/style.css
@@ -1,0 +1,31 @@
+window {
+    font-family: sans-serif;
+}
+
+.lock-button,
+.lock-card {
+    color: #f8fafc;
+    background: rgba(15, 23, 42, 0.94);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 14px;
+    padding: 14px;
+}
+
+.lock-card {
+    min-width: 320px;
+}
+
+.lock-title {
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 10px;
+}
+
+.error {
+    color: #fca5a5;
+    margin-bottom: 8px;
+}
+
+entry {
+    margin: 8px 0;
+}

--- a/example/polkit-agent/README.md
+++ b/example/polkit-agent/README.md
@@ -1,0 +1,11 @@
+# Polkit Agent Example
+
+This config demonstrates only the `polkit` service.
+
+Do not run it while another non-fallback polkit authentication agent is active.
+
+Run with:
+
+```sh
+ags --config example/polkit-agent/config.js
+```

--- a/example/polkit-agent/config.js
+++ b/example/polkit-agent/config.js
@@ -1,0 +1,62 @@
+const polkit = await Service.import("polkit")
+
+const password = Widget.Entry({
+    visibility: false,
+    placeholder_text: "Password",
+    on_accept: (self) => {
+        polkit.respond(self.text)
+        self.text = ""
+    },
+})
+
+function PolkitDialog() {
+    return Widget.Window({
+        name: "polkit-agent",
+        class_name: "polkit-agent",
+        layer: "overlay",
+        keymode: "exclusive",
+        visible: polkit.bind("active"),
+        child: Widget.Box({
+            vertical: true,
+            class_name: "polkit-card",
+            children: [
+                Widget.Label({
+                    class_name: "polkit-title",
+                    label: polkit.bind("current-request").as(request => {
+                        return request?.message || "Authentication Required"
+                    }),
+                }),
+                Widget.Label({
+                    class_name: "polkit-prompt",
+                    label: polkit.bind("prompt").as(prompt => prompt?.message || ""),
+                }),
+                password,
+                Widget.Box({
+                    hpack: "end",
+                    children: [
+                        Widget.Button({
+                            label: "Cancel",
+                            on_clicked: () => polkit.cancel(),
+                        }),
+                        Widget.Button({
+                            label: "Authenticate",
+                            on_clicked: () => {
+                                polkit.respond(password.text)
+                                password.text = ""
+                            },
+                        }),
+                    ],
+                }),
+            ],
+        }),
+    })
+}
+
+polkit.connect("request", () => Utils.timeout(100, () => password.grab_focus()))
+polkit.connect("show-error", (_, message) => print(`polkit: ${message}`))
+polkit.registerAgent()
+
+App.config({
+    style: App.configDir + "/style.css",
+    windows: [PolkitDialog()],
+})

--- a/example/polkit-agent/style.css
+++ b/example/polkit-agent/style.css
@@ -1,0 +1,30 @@
+window {
+    font-family: sans-serif;
+}
+
+.polkit-card {
+    min-width: 320px;
+    color: #f8fafc;
+    background: rgba(15, 23, 42, 0.94);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 14px;
+    padding: 14px;
+}
+
+.polkit-title {
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 10px;
+}
+
+.polkit-prompt {
+    margin-bottom: 8px;
+}
+
+entry {
+    margin: 8px 0;
+}
+
+button {
+    margin: 4px;
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,6 +27,8 @@
   libsoup_3,
   libnotify,
   pam,
+  polkit,
+  gtk-session-lock,
   # Extra Options
   extraPackages ? [],
   version ? "git",
@@ -103,6 +105,8 @@ in
         libsoup_3
         libnotify
         pam
+        polkit
+        gtk-session-lock
         glib
         gobject-introspection
       ];

--- a/src/com.github.Aylur.ags.src.gresource.xml
+++ b/src/com.github.Aylur.ags.src.gresource.xml
@@ -58,9 +58,11 @@
     <file>service/bluetooth.js</file>
     <file>service/greetd.js</file>
     <file>service/hyprland.js</file>
+    <file>service/lockscreen.js</file>
     <file>service/mpris.js</file>
     <file>service/network.js</file>
     <file>service/notifications.js</file>
+    <file>service/polkit.js</file>
     <file>service/powerprofiles.js</file>
     <file>service/systemtray.js</file>
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -39,7 +39,7 @@ typescript = custom_target(
   input: files( 'main.ts' ),
   build_by_default: true,
   build_always_stale: true,
-  command: [ tsc, '--outDir', tsc_out ],
+  command: [ tsc, '--project', meson.project_source_root() / 'tsconfig.json', '--outDir', tsc_out ],
   output: ['tsc-output'],
 )
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -163,9 +163,11 @@ interface Services {
     bluetooth: typeof import('./service/bluetooth.js').default;
     brightness: typeof import('./service/brightness.js').default;
     hyprland: typeof import('./service/hyprland.js').default;
+    lockscreen: typeof import('./service/lockscreen.js').default;
     mpris: typeof import('./service/mpris.js').default;
     network: typeof import('./service/network.js').default;
     notifications: typeof import('./service/notifications.js').default;
+    polkit: typeof import('./service/polkit.js').default;
     powerprofiles: typeof import('./service/powerprofiles.js').default;
     systemtray: typeof import('./service/systemtray.js').default;
     greetd: typeof import('./service/greetd.js').default;

--- a/src/service/lockscreen.ts
+++ b/src/service/lockscreen.ts
@@ -1,0 +1,208 @@
+import Gdk from 'gi://Gdk?version=3.0';
+import Gtk from 'gi://Gtk?version=3.0';
+import Service from '../service.js';
+import type { Disposable } from '../service.js';
+import { AgsServiceError } from '../utils/errors.js';
+import { authenticate, authenticateUser } from '../utils/pam.js';
+
+let GtkSessionLock: any = null;
+try {
+    // @ts-expect-error optional GIR dependency
+    GtkSessionLock = (await import('gi://GtkSessionLock?version=0.1')).default;
+} catch {
+    GtkSessionLock = null;
+}
+
+export type LockSurfaceFactory = (monitor: Gdk.Monitor, index: number) => Gtk.Window;
+
+/**
+ * Secure Wayland session-lock service.
+ *
+ * This wraps the `ext-session-lock-v1` protocol through `gtk-session-lock`.
+ * It intentionally has no fullscreen-window fallback: if the compositor or
+ * library is unavailable, {@link lock} throws instead of creating an insecure
+ * imitation of a lock screen.
+ *
+ * @property available        - Whether the compositor supports session-lock
+ * @property locked           - Whether the current session lock is active
+ * @property protocol_version - Supported ext-session-lock protocol version
+ */
+export class Lockscreen extends Service implements Disposable {
+    static {
+        Service.register(
+            this,
+            {
+                locked: [],
+                unlocked: [],
+                finished: [],
+            },
+            {
+                available: ['boolean', 'r'],
+                locked: ['boolean', 'r'],
+                'protocol-version': ['int', 'r'],
+            },
+        );
+    }
+
+    private _lock: any = null;
+    private _windows: Gtk.Window[] = [];
+    private _available = false;
+    private _locked = false;
+    private _protocolVersion = 0;
+    private _lockSignalIds: number[] = [];
+
+    get available() {
+        return this._available;
+    }
+
+    get locked() {
+        return this._locked;
+    }
+
+    get protocol_version() {
+        return this._protocolVersion;
+    }
+
+    constructor() {
+        super();
+        this.refresh();
+    }
+
+    /** Refreshes compositor support and protocol version. */
+    readonly refresh = () => {
+        this._available = Boolean(GtkSessionLock?.is_supported());
+        this._protocolVersion = GtkSessionLock ? Number(GtkSessionLock.get_protocol_version()) : 0;
+        this.notify('available');
+        this.notify('protocol-version');
+        this.emit('changed');
+    };
+
+    /**
+     * Locks the current Wayland session and creates one lock surface per monitor.
+     *
+     * The factory must return a new `Gtk.Window` for each monitor. Use normal AGS
+     * widgets as that window's child, but do not reuse an existing bar/popup
+     * window.
+     */
+    readonly lock = (createSurface: LockSurfaceFactory) => {
+        if (this._lock) return;
+
+        this.refresh();
+        if (!this._available) {
+            throw new AgsServiceError('Wayland session-lock is not available', {
+                protocolVersion: this._protocolVersion,
+            });
+        }
+
+        const display = Gdk.Display.get_default();
+        if (!display) {
+            throw new AgsServiceError('Cannot lock without a GDK display');
+        }
+
+        const lock = GtkSessionLock.prepare_lock();
+        this._lock = lock;
+        this._windows = [];
+        this._lockSignalIds = [
+            lock.connect('locked', () => {
+                this._locked = true;
+                this.notify('locked');
+                this.emit('locked');
+                this.emit('changed');
+            }),
+            lock.connect('finished', () => {
+                this._cleanupLock();
+                this.emit('finished');
+            }),
+        ];
+
+        try {
+            lock.lock_lock();
+
+            const nMonitors = display.get_n_monitors();
+            if (nMonitors < 1) {
+                throw new AgsServiceError('Cannot lock without monitors');
+            }
+
+            for (let i = 0; i < nMonitors; i++) {
+                const monitor = display.get_monitor(i);
+                if (!monitor) continue;
+                const window = createSurface(monitor, i);
+                this._windows.push(window);
+                lock.new_surface(window, monitor);
+                window.show_all();
+            }
+        } catch (error) {
+            if (this._locked) lock.unlock_and_destroy();
+            else lock.destroy();
+            this._cleanupLock();
+            throw error;
+        }
+    };
+
+    /** Unlocks an active lock after the caller has verified the user's identity. */
+    readonly unlock = () => {
+        if (!this._lock) return;
+        this._lock.unlock_and_destroy();
+        this._locked = false;
+        this.notify('locked');
+        this.emit('unlocked');
+        this.emit('changed');
+    };
+
+    /** Verifies a password with PAM and unlocks on success. */
+    readonly unlockWithPassword = async (password: string, username?: string, service = 'ags') => {
+        if (username) await authenticateUser(username, password, service);
+        else await authenticate(password, service);
+        this.unlock();
+    };
+
+    /** Cancels the current lock object if it has not become active yet. */
+    readonly cancel = () => {
+        if (!this._lock || this._locked) return;
+        this._lock.destroy();
+        this._cleanupLock();
+    };
+
+    private _cleanupLock() {
+        const lock = this._lock;
+        const display = Gdk.Display.get_default();
+        if (lock) {
+            for (const id of this._lockSignalIds) {
+                try {
+                    lock.disconnect(id);
+                } catch {
+                    // The lock may already be disposed by gtk-session-lock.
+                }
+            }
+        }
+
+        for (const window of this._windows) {
+            try {
+                window.destroy();
+            } catch {
+                window.destroy();
+            }
+        }
+
+        display?.sync();
+
+        this._lock = null;
+        this._windows = [];
+        this._lockSignalIds = [];
+        this._locked = false;
+        this.notify('locked');
+        this.emit('changed');
+    }
+
+    dispose(): void {
+        if (this._lock) {
+            if (this._locked) this.unlock();
+            else this.cancel();
+        }
+        this._cleanupLock();
+        super.dispose();
+    }
+}
+
+export const lockscreen = new Lockscreen();
+export default lockscreen;

--- a/src/service/polkit.ts
+++ b/src/service/polkit.ts
@@ -1,0 +1,248 @@
+// @ts-expect-error no types for locally-built GIR library
+import GUtils from 'gi://GUtils';
+import Service from '../service.js';
+import type { Disposable } from '../service.js';
+
+export type PolkitIdentity = {
+    id: string;
+    kind: string;
+    name?: string;
+    uid?: number;
+    gid?: number;
+};
+
+export type PolkitRequest = {
+    actionId: string;
+    message: string;
+    iconName: string;
+    details: Record<string, string>;
+    identities: PolkitIdentity[];
+};
+
+export type PolkitPrompt = {
+    message: string;
+    echoOn: boolean;
+};
+
+export type RegisterOptions = {
+    /** Register for this logind/ConsoleKit session id instead of this process' session. */
+    sessionId?: string;
+    /** D-Bus object path for the authentication agent. */
+    objectPath?: string;
+    /** Register as a fallback agent when another non-fallback agent exists. */
+    fallback?: boolean;
+};
+
+const DEFAULT_OBJECT_PATH = '/com/github/Aylur/ags/PolkitAgent';
+
+function unpackVariant<T>(variant: unknown): T {
+    const maybeVariant = variant as { deepUnpack?: () => T };
+    if (maybeVariant && typeof maybeVariant.deepUnpack === 'function')
+        return maybeVariant.deepUnpack();
+    return variant as T;
+}
+
+/**
+ * Polkit authentication agent service.
+ *
+ * The privileged response path is handled by `PolkitAgent.Session` in the
+ * native GUtils helper, which uses polkit's setuid helper. JavaScript code only
+ * receives the request metadata and sends responses to the active session.
+ *
+ * @property registered      - Whether this process is registered as an agent
+ * @property active          - Whether an authentication request is active
+ * @property current_request - Current action and identity metadata
+ * @property prompt          - Current PAM prompt
+ */
+export class Polkit extends Service implements Disposable {
+    static {
+        Service.register(
+            this,
+            {
+                begin: ['jsobject'],
+                request: ['jsobject'],
+                'show-info': ['string'],
+                'show-error': ['string'],
+                completed: ['boolean'],
+                cancelled: [],
+            },
+            {
+                registered: ['boolean', 'r'],
+                active: ['boolean', 'r'],
+                'current-request': ['jsobject', 'r'],
+                prompt: ['jsobject', 'r'],
+            },
+        );
+    }
+
+    private _agent: any = GUtils.PolkitAgent.new();
+    private _registered = false;
+    private _active = false;
+    private _currentRequest: PolkitRequest | null = null;
+    private _prompt: PolkitPrompt | null = null;
+
+    /**
+     * If true, the first offered identity is selected as soon as a request
+     * starts. Set this to false if your UI lets users choose an identity.
+     */
+    autoSelectIdentity = true;
+
+    get registered() {
+        return this._registered;
+    }
+
+    get active() {
+        return this._active;
+    }
+
+    get current_request() {
+        return this._currentRequest;
+    }
+
+    get prompt() {
+        return this._prompt;
+    }
+
+    constructor() {
+        super();
+
+        this.trackConnection(
+            this._agent,
+            this._agent.connect(
+                'begin',
+                (
+                    _agent: unknown,
+                    actionId: string,
+                    message: string,
+                    iconName: string,
+                    details: unknown,
+                    identities: unknown,
+                ) => {
+                    this._active = true;
+                    this._prompt = null;
+                    this._currentRequest = {
+                        actionId,
+                        message,
+                        iconName,
+                        details: unpackVariant<Record<string, string>>(details),
+                        identities: unpackVariant<PolkitIdentity[]>(identities),
+                    };
+                    this.notify('active');
+                    this.notify('prompt');
+                    this.notify('current-request');
+                    this.emit('begin', this._currentRequest);
+                    this.emit('changed');
+
+                    if (this.autoSelectIdentity && this._currentRequest.identities.length > 0) {
+                        this.selectIdentity(0);
+                    }
+                },
+            ),
+        );
+
+        this.trackConnection(
+            this._agent,
+            this._agent.connect('request', (_agent: unknown, message: string, echoOn: boolean) => {
+                this._prompt = { message, echoOn };
+                this.notify('prompt');
+                this.emit('request', this._prompt);
+                this.emit('changed');
+            }),
+        );
+
+        this.trackConnection(
+            this._agent,
+            this._agent.connect('show-info', (_agent: unknown, text: string) => {
+                this.emit('show-info', text);
+            }),
+        );
+
+        this.trackConnection(
+            this._agent,
+            this._agent.connect('show-error', (_agent: unknown, text: string) => {
+                this.emit('show-error', text);
+            }),
+        );
+
+        this.trackConnection(
+            this._agent,
+            this._agent.connect('completed', (_agent: unknown, authorized: boolean) => {
+                this._clearActive();
+                this.emit('completed', authorized);
+            }),
+        );
+
+        this.trackConnection(
+            this._agent,
+            this._agent.connect('cancelled', () => {
+                this._clearActive();
+                this.emit('cancelled');
+            }),
+        );
+    }
+
+    /** Registers this process as the polkit authentication agent. */
+    readonly registerAgent = (options: RegisterOptions = {}) => {
+        if (this._registered) return;
+
+        this._agent.register(
+            options.sessionId ?? '',
+            options.objectPath ?? DEFAULT_OBJECT_PATH,
+            options.fallback ?? false,
+            null,
+        );
+        this._registered = true;
+        this.notify('registered');
+        this.emit('changed');
+    };
+
+    /** Unregisters this process as the polkit authentication agent. */
+    readonly unregisterAgent = () => {
+        if (!this._registered) return;
+        this._agent.unregister();
+        this._registered = false;
+        this._clearActive();
+        this.notify('registered');
+        this.emit('changed');
+    };
+
+    /** Selects which offered identity to authenticate as. */
+    readonly selectIdentity = (index: number) => {
+        if (!Number.isInteger(index) || index < 0) {
+            throw new RangeError('Identity index must be a non-negative integer');
+        }
+
+        this._agent.select_identity(index);
+    };
+
+    /** Sends a response to the current PAM prompt. */
+    readonly respond = (response: string) => {
+        this._agent.response(response);
+        this._prompt = null;
+        this.notify('prompt');
+        this.emit('changed');
+    };
+
+    /** Cancels the current authentication request. */
+    readonly cancel = () => {
+        this._agent.cancel();
+    };
+
+    private _clearActive() {
+        this._active = false;
+        this._currentRequest = null;
+        this._prompt = null;
+        this.notify('active');
+        this.notify('current-request');
+        this.notify('prompt');
+        this.emit('changed');
+    }
+
+    dispose(): void {
+        this.unregisterAgent();
+        super.dispose();
+    }
+}
+
+export const polkit = new Polkit();
+export default polkit;

--- a/src/utils/pam.ts
+++ b/src/utils/pam.ts
@@ -16,15 +16,21 @@ import Gio from 'gi://Gio';
  * @param password - The password to verify
  * @returns A promise that resolves on success or rejects on failure
  */
-export function authenticate(password: string) {
+export function authenticate(password: string, service = 'ags') {
     return new Promise((resolve, reject) => {
-        GUtils.authenticate(password, 0, null, (_: unknown, res: Gio.AsyncResult) => {
-            try {
-                resolve(GUtils.authenticate_finish(res));
-            } catch (e) {
-                reject(e);
-            }
-        });
+        GUtils.authenticate_for_service(
+            service,
+            password,
+            0,
+            null,
+            (_: unknown, res: Gio.AsyncResult) => {
+                try {
+                    resolve(GUtils.authenticate_finish(res));
+                } catch (e) {
+                    reject(e);
+                }
+            },
+        );
     });
 }
 
@@ -35,9 +41,10 @@ export function authenticate(password: string) {
  * @param password - The password to verify
  * @returns A promise that resolves on success or rejects on failure
  */
-export function authenticateUser(username: string, password: string) {
+export function authenticateUser(username: string, password: string, service = 'ags') {
     return new Promise((resolve, reject) => {
-        GUtils.authenticate_user(
+        GUtils.authenticate_user_for_service(
+            service,
             username,
             password,
             0,

--- a/subprojects/gutils/meson.build
+++ b/subprojects/gutils/meson.build
@@ -5,11 +5,18 @@ pkgdatadir = get_option('pkgdatadir')
 
 cc = meson.get_compiler('c')
 
+add_project_arguments(
+  '-DPOLKIT_AGENT_I_KNOW_API_IS_SUBJECT_TO_CHANGE',
+  language: 'c',
+)
+
 libsources = ['pam.c', 'pam.h']
 
 deps = [
   dependency('gobject-2.0'),
   dependency('gio-2.0'),
+  dependency('polkit-agent-1'),
+  dependency('polkit-gobject-1'),
   dependency('pam')
 ]
 
@@ -28,7 +35,7 @@ gnome.generate_gir(
   namespace: 'GUtils',
   symbol_prefix: 'gutils',
   identifier_prefix: 'GUtils',
-  includes: ['GObject-2.0', 'Gio-2.0'],
+  includes: ['GObject-2.0', 'Gio-2.0', 'PolkitAgent-1.0', 'Polkit-1.0'],
   install_dir_gir: pkgdatadir,
   install_dir_typelib: pkglibdir,
   install: true

--- a/subprojects/gutils/pam.c
+++ b/subprojects/gutils/pam.c
@@ -1,74 +1,77 @@
 #include "pam.h"
 #include <gio/gio.h>
+#include <polkit/polkit.h>
+#include <polkitagent/polkitagent.h>
 #include <pwd.h>
 #include <security/pam_appl.h>
 #include <string.h>
+#include <unistd.h>
 
 typedef struct {
-    gchar *username;
-    gchar *password;
+  gchar *service;
+  gchar *username;
+  gchar *password;
 } auth_info;
 
-void free_auth_info(void* data) {
-    auth_info* info = (auth_info*) data;
-    free(info->username);
-    free(info->password);
-    free(info);
+void free_auth_info(void *data) {
+  auth_info *info = (auth_info *)data;
+  free(info->service);
+  free(info->username);
+  free(info->password);
+  free(info);
 }
 
-int handle_conversation(int                         num_msg,
-                        const struct pam_message  **msg,
-                        struct pam_response       **resp,
-                        void                       *appdata_ptr) {
-    struct pam_response *replies = NULL;
-    if (num_msg <= 0 || num_msg > PAM_MAX_NUM_MSG) {
-        return PAM_CONV_ERR;
+int handle_conversation(int num_msg, const struct pam_message **msg,
+                        struct pam_response **resp, void *appdata_ptr) {
+  struct pam_response *replies = NULL;
+  if (num_msg <= 0 || num_msg > PAM_MAX_NUM_MSG) {
+    return PAM_CONV_ERR;
+  }
+  replies = (struct pam_response *)calloc(num_msg, sizeof(struct pam_response));
+  if (replies == NULL) {
+    return PAM_BUF_ERR;
+  }
+  for (int i = 0; i < num_msg; ++i) {
+    switch (msg[i]->msg_style) {
+    case PAM_PROMPT_ECHO_OFF:
+    case PAM_PROMPT_ECHO_ON:
+      replies[i].resp = strdup((const char *)appdata_ptr);
+      if (replies[i].resp == NULL) {
+        return PAM_ABORT;
+      }
+      break;
+    case PAM_ERROR_MSG:
+    case PAM_TEXT_INFO:
+      break;
     }
-    replies = (struct pam_response *)calloc(num_msg, sizeof(struct pam_response));
-    if (replies == NULL){
-        return PAM_BUF_ERR;
-    }
-    for (int i = 0; i < num_msg; ++i) {
-        switch (msg[i]->msg_style) {
-            case PAM_PROMPT_ECHO_OFF:
-            case PAM_PROMPT_ECHO_ON:
-                replies[i].resp = strdup((const char *)appdata_ptr);
-                if (replies[i].resp == NULL) {
-                    return PAM_ABORT;
-                }
-                break;
-            case PAM_ERROR_MSG:
-            case PAM_TEXT_INFO:
-                break;
-        }
-    }
-    *resp = replies;
-    return PAM_SUCCESS;
+  }
+  *resp = replies;
+  return PAM_SUCCESS;
 }
 
-void auth_thread (GTask         *task,
-                  gpointer       object,
-                  gpointer       task_data,
-                  GCancellable  *cancellable) {
-    auth_info *info = (auth_info *)task_data;
+void auth_thread(GTask *task, gpointer object, gpointer task_data,
+                 GCancellable *cancellable) {
+  (void)object;
+  (void)cancellable;
+  auth_info *info = (auth_info *)task_data;
 
-    pam_handle_t *pamh = NULL;
-    const struct pam_conv conv = {
+  pam_handle_t *pamh = NULL;
+  const struct pam_conv conv = {
       .conv = handle_conversation,
-      .appdata_ptr = (void *) info->password,
-    };
-    int retval;
-    retval = pam_start("ags", info->username, &conv, &pamh);
-    if (retval == PAM_SUCCESS) {
-        retval = pam_authenticate(pamh, 0);
-        pam_end(pamh, retval);
-    }
-    if (retval != PAM_SUCCESS) {
-        g_task_return_new_error(task, G_IO_ERROR, G_IO_ERROR_FAILED, "%s", pam_strerror(pamh, retval));
-    }
-    else {
-        g_task_return_int(task, retval);
-    }
+      .appdata_ptr = (void *)info->password,
+  };
+  int retval;
+  retval = pam_start(info->service, info->username, &conv, &pamh);
+  if (retval == PAM_SUCCESS) {
+    retval = pam_authenticate(pamh, 0);
+    pam_end(pamh, retval);
+  }
+  if (retval != PAM_SUCCESS) {
+    g_task_return_new_error(task, G_IO_ERROR, G_IO_ERROR_FAILED, "%s",
+                            pam_strerror(pamh, retval));
+  } else {
+    g_task_return_int(task, retval);
+  }
 }
 
 /**
@@ -82,30 +85,38 @@ void auth_thread (GTask         *task,
  *   to call when the request is satisfied
  * @user_data: the data to pass to callback function
  *
- * Requests authentication of the provided password for the specified username using the PAM (Pluggable Authentication Modules) system.
+ * Requests authentication of the provided password for the specified username
+ * using the PAM (Pluggable Authentication Modules) system.
  */
-void gutils_authenticate_user (const gchar*         username,
-                               const gchar*         password,
-                               int                  io_priority,
-                               GCancellable        *cancellable,
-                               GAsyncReadyCallback  callback,
-                               gpointer             user_data) {
-    auth_info *info = (auth_info *) malloc(sizeof(auth_info));
-    if (info == NULL) return;
-    info->username = strdup(username);
-    info->password = strdup(password);
+void gutils_authenticate_user_for_service(
+    const gchar *service, const gchar *username, const gchar *password,
+    int io_priority, GCancellable *cancellable, GAsyncReadyCallback callback,
+    gpointer user_data) {
+  auth_info *info = (auth_info *)malloc(sizeof(auth_info));
+  if (info == NULL)
+    return;
+  info->service = strdup(service);
+  info->username = strdup(username);
+  info->password = strdup(password);
 
-    GTask *task;
-    task = g_task_new (NULL, cancellable, callback, user_data);
-    g_task_set_task_data(task, info, free_auth_info);
-    g_task_set_priority(task, io_priority);
-    g_task_run_in_thread(task, auth_thread);
-    g_object_unref (task);
+  GTask *task;
+  task = g_task_new(NULL, cancellable, callback, user_data);
+  g_task_set_task_data(task, info, free_auth_info);
+  g_task_set_priority(task, io_priority);
+  g_task_run_in_thread(task, auth_thread);
+  g_object_unref(task);
 }
 
-int gutils_authenticate_user_finish(GAsyncResult  *res,
-                                    GError       **error) {
-    return g_task_propagate_int(G_TASK(res), error) ;
+void gutils_authenticate_user(const gchar *username, const gchar *password,
+                              int io_priority, GCancellable *cancellable,
+                              GAsyncReadyCallback callback,
+                              gpointer user_data) {
+  return gutils_authenticate_user_for_service(
+      "ags", username, password, io_priority, cancellable, callback, user_data);
+}
+
+int gutils_authenticate_user_finish(GAsyncResult *res, GError **error) {
+  return g_task_propagate_int(G_TASK(res), error);
 }
 
 /**
@@ -118,20 +129,424 @@ int gutils_authenticate_user_finish(GAsyncResult  *res,
  *   to call when the request is satisfied
  * @user_data: the data to pass to callback function
  *
- * Requests authentication of the provided password using the PAM (Pluggable Authentication Modules) system.
+ * Requests authentication of the provided password using the PAM (Pluggable
+ * Authentication Modules) system.
  */
-void gutils_authenticate (const gchar*         password,
-                          int                  io_priority,
-                          GCancellable        *cancellable,
-                          GAsyncReadyCallback  callback,
-                          gpointer             user_data) {
-    struct passwd *passwd = getpwuid(getuid());
-    char *username = passwd->pw_name;
+void gutils_authenticate_for_service(const gchar *service,
+                                     const gchar *password, int io_priority,
+                                     GCancellable *cancellable,
+                                     GAsyncReadyCallback callback,
+                                     gpointer user_data) {
+  struct passwd *passwd = getpwuid(getuid());
+  char *username = passwd->pw_name;
 
-    return gutils_authenticate_user(username, password, io_priority, cancellable, callback, user_data);
+  return gutils_authenticate_user_for_service(service, username, password,
+                                              io_priority, cancellable,
+                                              callback, user_data);
 }
 
-int gutils_authenticate_finish(GAsyncResult  *res,
-                               GError       **error){
-    return g_task_propagate_int(G_TASK(res), error) ;
+void gutils_authenticate(const gchar *password, int io_priority,
+                         GCancellable *cancellable,
+                         GAsyncReadyCallback callback, gpointer user_data) {
+  return gutils_authenticate_for_service("ags", password, io_priority,
+                                         cancellable, callback, user_data);
 }
+
+int gutils_authenticate_finish(GAsyncResult *res, GError **error) {
+  return g_task_propagate_int(G_TASK(res), error);
+}
+
+typedef struct {
+  gpointer registration_handle;
+  PolkitSubject *subject;
+
+  gchar *cookie;
+  GList *identities;
+  PolkitAgentSession *session;
+  GTask *task;
+  GCancellable *cancellable;
+  gulong cancellable_id;
+  gboolean completed;
+} GUtilsPolkitAgentPrivate;
+
+struct _GUtilsPolkitAgent {
+  PolkitAgentListener parent_instance;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GUtilsPolkitAgent, gutils_polkit_agent,
+                           POLKIT_AGENT_TYPE_LISTENER)
+
+enum {
+  BEGIN,
+  REQUEST,
+  SHOW_INFO,
+  SHOW_ERROR,
+  COMPLETED,
+  CANCELLED,
+  LAST_SIGNAL,
+};
+
+static guint polkit_agent_signals[LAST_SIGNAL];
+
+static GVariant *details_to_variant(PolkitDetails *details) {
+  GVariantBuilder builder;
+  g_variant_builder_init(&builder, G_VARIANT_TYPE("a{ss}"));
+
+  if (details != NULL) {
+    gchar **keys = polkit_details_get_keys(details);
+    if (keys != NULL) {
+      for (gchar **key = keys; *key != NULL; key++) {
+        const gchar *value = polkit_details_lookup(details, *key);
+        if (value != NULL) {
+          g_variant_builder_add(&builder, "{ss}", *key, value);
+        }
+      }
+      g_strfreev(keys);
+    }
+  }
+
+  return g_variant_ref_sink(g_variant_builder_end(&builder));
+}
+
+static GVariant *identities_to_variant(GList *identities) {
+  GVariantBuilder builder;
+  g_variant_builder_init(&builder, G_VARIANT_TYPE("aa{sv}"));
+
+  for (GList *l = identities; l != NULL; l = l->next) {
+    PolkitIdentity *identity = POLKIT_IDENTITY(l->data);
+    g_autofree gchar *identity_string = polkit_identity_to_string(identity);
+    GVariantBuilder item;
+    g_variant_builder_init(&item, G_VARIANT_TYPE("a{sv}"));
+
+    g_variant_builder_add(&item, "{sv}", "kind",
+                          g_variant_new_string(G_OBJECT_TYPE_NAME(identity)));
+    g_variant_builder_add(&item, "{sv}", "id",
+                          g_variant_new_string(identity_string));
+
+    if (POLKIT_IS_UNIX_USER(identity)) {
+      PolkitUnixUser *user = POLKIT_UNIX_USER(identity);
+      const gchar *name = polkit_unix_user_get_name(user);
+      g_variant_builder_add(
+          &item, "{sv}", "uid",
+          g_variant_new_int32(polkit_unix_user_get_uid(user)));
+      if (name != NULL) {
+        g_variant_builder_add(&item, "{sv}", "name",
+                              g_variant_new_string(name));
+      }
+    } else if (POLKIT_IS_UNIX_GROUP(identity)) {
+      PolkitUnixGroup *group = POLKIT_UNIX_GROUP(identity);
+      g_variant_builder_add(
+          &item, "{sv}", "gid",
+          g_variant_new_int32(polkit_unix_group_get_gid(group)));
+    }
+
+    g_variant_builder_add(&builder, "a{sv}", &item);
+  }
+
+  return g_variant_ref_sink(g_variant_builder_end(&builder));
+}
+
+static gpointer copy_identity(gconstpointer identity, gpointer user_data) {
+  (void)user_data;
+  return g_object_ref((gpointer)identity);
+}
+
+static void clear_authentication(GUtilsPolkitAgent *agent) {
+  GUtilsPolkitAgentPrivate *priv =
+      gutils_polkit_agent_get_instance_private(agent);
+
+  if (priv->cancellable != NULL && priv->cancellable_id != 0) {
+    g_cancellable_disconnect(priv->cancellable, priv->cancellable_id);
+    priv->cancellable_id = 0;
+  }
+
+  g_clear_object(&priv->cancellable);
+  g_clear_object(&priv->session);
+  g_clear_object(&priv->task);
+  g_clear_pointer(&priv->cookie, g_free);
+  g_clear_list(&priv->identities, g_object_unref);
+  priv->completed = FALSE;
+}
+
+static void finish_authentication(GUtilsPolkitAgent *agent, gboolean authorized,
+                                  gboolean cancelled) {
+  GUtilsPolkitAgentPrivate *priv =
+      gutils_polkit_agent_get_instance_private(agent);
+
+  if (priv->completed) {
+    return;
+  }
+  priv->completed = TRUE;
+
+  if (priv->task != NULL) {
+    if (authorized) {
+      g_task_return_boolean(priv->task, TRUE);
+    } else if (cancelled) {
+      g_task_return_new_error(priv->task, G_IO_ERROR, G_IO_ERROR_CANCELLED,
+                              "Authentication was cancelled");
+    } else {
+      g_task_return_new_error(priv->task, G_IO_ERROR,
+                              G_IO_ERROR_PERMISSION_DENIED,
+                              "Authentication failed");
+    }
+  }
+
+  g_signal_emit(agent, polkit_agent_signals[COMPLETED], 0, authorized);
+  clear_authentication(agent);
+}
+
+static void on_agent_session_request(PolkitAgentSession *session,
+                                     const gchar *request, gboolean echo_on,
+                                     gpointer user_data) {
+  (void)session;
+  g_signal_emit(user_data, polkit_agent_signals[REQUEST], 0, request, echo_on);
+}
+
+static void on_agent_session_show_info(PolkitAgentSession *session,
+                                       const gchar *text, gpointer user_data) {
+  (void)session;
+  g_signal_emit(user_data, polkit_agent_signals[SHOW_INFO], 0, text);
+}
+
+static void on_agent_session_show_error(PolkitAgentSession *session,
+                                        const gchar *text, gpointer user_data) {
+  (void)session;
+  g_signal_emit(user_data, polkit_agent_signals[SHOW_ERROR], 0, text);
+}
+
+static void on_agent_session_completed(PolkitAgentSession *session,
+                                       gboolean gained_authorization,
+                                       gpointer user_data) {
+  (void)session;
+  finish_authentication(GUTILS_POLKIT_AGENT(user_data), gained_authorization,
+                        FALSE);
+}
+
+static void on_authentication_cancelled(GCancellable *cancellable,
+                                        gpointer user_data) {
+  (void)cancellable;
+  GUtilsPolkitAgent *agent = GUTILS_POLKIT_AGENT(user_data);
+  GUtilsPolkitAgentPrivate *priv =
+      gutils_polkit_agent_get_instance_private(agent);
+
+  if (priv->session != NULL) {
+    polkit_agent_session_cancel(priv->session);
+  }
+  g_signal_emit(agent, polkit_agent_signals[CANCELLED], 0);
+  finish_authentication(agent, FALSE, TRUE);
+}
+
+static void gutils_polkit_agent_initiate_authentication(
+    PolkitAgentListener *listener, const gchar *action_id, const gchar *message,
+    const gchar *icon_name, PolkitDetails *details, const gchar *cookie,
+    GList *identities, GCancellable *cancellable, GAsyncReadyCallback callback,
+    gpointer user_data) {
+  GUtilsPolkitAgent *agent = GUTILS_POLKIT_AGENT(listener);
+  GUtilsPolkitAgentPrivate *priv =
+      gutils_polkit_agent_get_instance_private(agent);
+
+  if (priv->task != NULL) {
+    g_autoptr(GTask) task =
+        g_task_new(listener, cancellable, callback, user_data);
+    g_task_return_new_error(task, G_IO_ERROR, G_IO_ERROR_BUSY,
+                            "Another authentication request is already active");
+    return;
+  }
+
+  priv->task = g_task_new(listener, cancellable, callback, user_data);
+  priv->cookie = g_strdup(cookie);
+  priv->identities = g_list_copy_deep(identities, copy_identity, NULL);
+  if (cancellable != NULL) {
+    priv->cancellable = g_object_ref(cancellable);
+    priv->cancellable_id = g_cancellable_connect(
+        cancellable, G_CALLBACK(on_authentication_cancelled), agent, NULL);
+  }
+
+  g_autoptr(GVariant) details_variant = details_to_variant(details);
+  g_autoptr(GVariant) identities_variant = identities_to_variant(identities);
+  g_signal_emit(agent, polkit_agent_signals[BEGIN], 0, action_id, message,
+                icon_name != NULL ? icon_name : "", details_variant,
+                identities_variant);
+}
+
+static gboolean gutils_polkit_agent_initiate_authentication_finish(
+    PolkitAgentListener *listener, GAsyncResult *res, GError **error) {
+  (void)listener;
+  return g_task_propagate_boolean(G_TASK(res), error);
+}
+
+GUtilsPolkitAgent *gutils_polkit_agent_new(void) {
+  return g_object_new(GUTILS_TYPE_POLKIT_AGENT, NULL);
+}
+
+gboolean
+gutils_polkit_agent_register(GUtilsPolkitAgent *agent, const gchar *session_id,
+                             const gchar *object_path, gboolean fallback,
+                             GCancellable *cancellable, GError **error) {
+  GUtilsPolkitAgentPrivate *priv;
+  g_autoptr(PolkitSubject) subject = NULL;
+
+  g_return_val_if_fail(GUTILS_IS_POLKIT_AGENT(agent), FALSE);
+
+  priv = gutils_polkit_agent_get_instance_private(agent);
+  if (priv->registration_handle != NULL) {
+    return TRUE;
+  }
+
+  if (session_id != NULL && *session_id != '\0') {
+    subject = polkit_unix_session_new(session_id);
+  } else {
+    subject =
+        polkit_unix_session_new_for_process_sync(getpid(), cancellable, error);
+  }
+
+  if (subject == NULL) {
+    return FALSE;
+  }
+
+  if (fallback) {
+    g_autoptr(GVariant) options =
+        g_variant_ref_sink(g_variant_new_parsed("{ 'fallback': <%b> }", TRUE));
+    priv->registration_handle = polkit_agent_listener_register_with_options(
+        POLKIT_AGENT_LISTENER(agent), POLKIT_AGENT_REGISTER_FLAGS_NONE, subject,
+        object_path, options, cancellable, error);
+  } else {
+    priv->registration_handle = polkit_agent_listener_register(
+        POLKIT_AGENT_LISTENER(agent), POLKIT_AGENT_REGISTER_FLAGS_NONE, subject,
+        object_path, cancellable, error);
+  }
+
+  if (priv->registration_handle == NULL) {
+    return FALSE;
+  }
+
+  priv->subject = g_object_ref(subject);
+  return TRUE;
+}
+
+void gutils_polkit_agent_unregister(GUtilsPolkitAgent *agent) {
+  GUtilsPolkitAgentPrivate *priv;
+
+  g_return_if_fail(GUTILS_IS_POLKIT_AGENT(agent));
+
+  priv = gutils_polkit_agent_get_instance_private(agent);
+  if (priv->registration_handle != NULL) {
+    polkit_agent_listener_unregister(priv->registration_handle);
+    priv->registration_handle = NULL;
+  }
+
+  clear_authentication(agent);
+  g_clear_object(&priv->subject);
+}
+
+gboolean gutils_polkit_agent_select_identity(GUtilsPolkitAgent *agent,
+                                             guint index, GError **error) {
+  GUtilsPolkitAgentPrivate *priv;
+  PolkitIdentity *identity;
+
+  g_return_val_if_fail(GUTILS_IS_POLKIT_AGENT(agent), FALSE);
+
+  priv = gutils_polkit_agent_get_instance_private(agent);
+  if (priv->task == NULL || priv->cookie == NULL) {
+    g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                "No active authentication request");
+    return FALSE;
+  }
+  if (priv->session != NULL) {
+    return TRUE;
+  }
+
+  identity = g_list_nth_data(priv->identities, index);
+  if (identity == NULL) {
+    g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                "Identity index is out of range");
+    return FALSE;
+  }
+
+  priv->session = polkit_agent_session_new(identity, priv->cookie);
+  g_signal_connect(priv->session, "request",
+                   G_CALLBACK(on_agent_session_request), agent);
+  g_signal_connect(priv->session, "show-info",
+                   G_CALLBACK(on_agent_session_show_info), agent);
+  g_signal_connect(priv->session, "show-error",
+                   G_CALLBACK(on_agent_session_show_error), agent);
+  g_signal_connect(priv->session, "completed",
+                   G_CALLBACK(on_agent_session_completed), agent);
+  polkit_agent_session_initiate(priv->session);
+
+  return TRUE;
+}
+
+gboolean gutils_polkit_agent_response(GUtilsPolkitAgent *agent,
+                                      const gchar *response, GError **error) {
+  GUtilsPolkitAgentPrivate *priv;
+
+  g_return_val_if_fail(GUTILS_IS_POLKIT_AGENT(agent), FALSE);
+
+  priv = gutils_polkit_agent_get_instance_private(agent);
+  if (priv->session == NULL) {
+    g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                "No active authentication session");
+    return FALSE;
+  }
+
+  polkit_agent_session_response(priv->session, response);
+  return TRUE;
+}
+
+void gutils_polkit_agent_cancel(GUtilsPolkitAgent *agent) {
+  GUtilsPolkitAgentPrivate *priv;
+
+  g_return_if_fail(GUTILS_IS_POLKIT_AGENT(agent));
+
+  priv = gutils_polkit_agent_get_instance_private(agent);
+  if (priv->task == NULL) {
+    return;
+  }
+
+  g_signal_emit(agent, polkit_agent_signals[CANCELLED], 0);
+  if (priv->session != NULL) {
+    polkit_agent_session_cancel(priv->session);
+    finish_authentication(agent, FALSE, TRUE);
+  } else {
+    finish_authentication(agent, FALSE, TRUE);
+  }
+}
+
+static void gutils_polkit_agent_dispose(GObject *object) {
+  gutils_polkit_agent_unregister(GUTILS_POLKIT_AGENT(object));
+  G_OBJECT_CLASS(gutils_polkit_agent_parent_class)->dispose(object);
+}
+
+static void gutils_polkit_agent_class_init(GUtilsPolkitAgentClass *klass) {
+  GObjectClass *object_class = G_OBJECT_CLASS(klass);
+  PolkitAgentListenerClass *listener_class = POLKIT_AGENT_LISTENER_CLASS(klass);
+
+  object_class->dispose = gutils_polkit_agent_dispose;
+  listener_class->initiate_authentication =
+      gutils_polkit_agent_initiate_authentication;
+  listener_class->initiate_authentication_finish =
+      gutils_polkit_agent_initiate_authentication_finish;
+
+  polkit_agent_signals[BEGIN] = g_signal_new(
+      "begin", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST, 0, NULL, NULL, NULL,
+      G_TYPE_NONE, 5, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING,
+      G_TYPE_VARIANT, G_TYPE_VARIANT);
+  polkit_agent_signals[REQUEST] = g_signal_new(
+      "request", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST, 0, NULL, NULL,
+      NULL, G_TYPE_NONE, 2, G_TYPE_STRING, G_TYPE_BOOLEAN);
+  polkit_agent_signals[SHOW_INFO] =
+      g_signal_new("show-info", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST, 0,
+                   NULL, NULL, NULL, G_TYPE_NONE, 1, G_TYPE_STRING);
+  polkit_agent_signals[SHOW_ERROR] =
+      g_signal_new("show-error", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST, 0,
+                   NULL, NULL, NULL, G_TYPE_NONE, 1, G_TYPE_STRING);
+  polkit_agent_signals[COMPLETED] =
+      g_signal_new("completed", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST, 0,
+                   NULL, NULL, NULL, G_TYPE_NONE, 1, G_TYPE_BOOLEAN);
+  polkit_agent_signals[CANCELLED] =
+      g_signal_new("cancelled", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST, 0,
+                   NULL, NULL, NULL, G_TYPE_NONE, 0);
+}
+
+static void gutils_polkit_agent_init(GUtilsPolkitAgent *agent) { (void)agent; }

--- a/subprojects/gutils/pam.h
+++ b/subprojects/gutils/pam.h
@@ -1,30 +1,61 @@
 #ifndef PAM_H
 #define PAM_H
 
-#include <glib-object.h>
 #include <gio/gio.h>
+#include <glib-object.h>
+
+#ifndef POLKIT_AGENT_I_KNOW_API_IS_SUBJECT_TO_CHANGE
+#define POLKIT_AGENT_I_KNOW_API_IS_SUBJECT_TO_CHANGE
+#endif
+
+#include <polkitagent/polkitagent.h>
 
 G_BEGIN_DECLS
 
-void gutils_authenticate_user (const char*          username,
-                               const char*          password,
-                               int                  io_priority,
-                               GCancellable        *cancellable,
-                               GAsyncReadyCallback  callback,
-                               gpointer             user_data);
+void gutils_authenticate_user(const char *username, const char *password,
+                              int io_priority, GCancellable *cancellable,
+                              GAsyncReadyCallback callback, gpointer user_data);
 
-int gutils_authenticate_user_finish (GAsyncResult  *res,
-                                     GError **error);
+void gutils_authenticate_user_for_service(const char *service,
+                                          const char *username,
+                                          const char *password, int io_priority,
+                                          GCancellable *cancellable,
+                                          GAsyncReadyCallback callback,
+                                          gpointer user_data);
 
+int gutils_authenticate_user_finish(GAsyncResult *res, GError **error);
 
-void gutils_authenticate (const char*          password,
-                          int                  io_priority,
-                          GCancellable        *cancellable,
-                          GAsyncReadyCallback  callback,
-                          gpointer             user_data);
+void gutils_authenticate(const char *password, int io_priority,
+                         GCancellable *cancellable,
+                         GAsyncReadyCallback callback, gpointer user_data);
 
-int gutils_authenticate_finish (GAsyncResult  *res,
-                                GError       **error);
+void gutils_authenticate_for_service(const char *service, const char *password,
+                                     int io_priority, GCancellable *cancellable,
+                                     GAsyncReadyCallback callback,
+                                     gpointer user_data);
+
+int gutils_authenticate_finish(GAsyncResult *res, GError **error);
+
+#define GUTILS_TYPE_POLKIT_AGENT (gutils_polkit_agent_get_type())
+G_DECLARE_FINAL_TYPE(GUtilsPolkitAgent, gutils_polkit_agent, GUTILS,
+                     POLKIT_AGENT, PolkitAgentListener)
+
+GUtilsPolkitAgent *gutils_polkit_agent_new(void);
+
+gboolean
+gutils_polkit_agent_register(GUtilsPolkitAgent *agent, const gchar *session_id,
+                             const gchar *object_path, gboolean fallback,
+                             GCancellable *cancellable, GError **error);
+
+void gutils_polkit_agent_unregister(GUtilsPolkitAgent *agent);
+
+gboolean gutils_polkit_agent_select_identity(GUtilsPolkitAgent *agent,
+                                             guint index, GError **error);
+
+gboolean gutils_polkit_agent_response(GUtilsPolkitAgent *agent,
+                                      const gchar *response, GError **error);
+
+void gutils_polkit_agent_cancel(GUtilsPolkitAgent *agent);
 
 G_END_DECLS
 


### PR DESCRIPTION
I'd like to drop swaylock after all those years, so this PR introduces two major new built-in services to RAGS: a secure Wayland session lock service (`lockscreen`) and a Polkit authentication agent service (`polkit`). Now it should be possible to design a secure Wayland screenlocker and your own polkit agent without needing to install a billion new dependencies. The documentation and installation instructions have been updated accordingly.