### PR TITLE
fix mullvad-gui tray icon

### DIFF
--- a/src/service/systemtray.ts
+++ b/src/service/systemtray.ts
@@ -430,8 +430,14 @@ export class SystemTray extends Service implements Disposable {
             objectPath = service;
             busName = invocation.get_sender()!;
         } else {
-            busName = service;
-            objectPath = '/StatusNotifierItem';
+            const pathStart = service.indexOf('/');
+            if (pathStart > 0) {
+                busName = service.slice(0, pathStart);
+                objectPath = service.slice(pathStart);
+            } else {
+                busName = service;
+                objectPath = '/StatusNotifierItem';
+            }
         }
 
         invocation.return_value(null);


### PR DESCRIPTION
this error shows when launching rags

```
(com.github.Aylur.ags.gjs:31377): GLib-GIO-CRITICAL **: 01:43:53.052: g_dbus_connection_signal_subscribe: assertion 'sender == NULL || (g_dbus_is_name (sender) && (connection->flags & G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION))' failed
```
the mullvad tray icon does not show, and the tray icon is not interactable. 
<img width="400" height="40" alt="image" src="https://github.com/user-attachments/assets/ca28e1f0-b29c-4827-8f4e-fce2b0dec474" />

trying to click on it gives the error

```
(com.github.Aylur.ags.gjs:31377): GLib-GIO-CRITICAL **: 01:45:01.405: g_dbus_connection_call_internal: assertion 'bus_name == NULL || g_dbus_is_name (bus_name)' failed
```

this fixes it :)